### PR TITLE
fix syllable builder

### DIFF
--- a/tamil-seiyul-alagi/src/letter.rs
+++ b/tamil-seiyul-alagi/src/letter.rs
@@ -15,7 +15,6 @@ pub fn to_prosodic_units(graphemes: &[&str]) -> Vec<ProsodicUnit> {
             // Pure Vowels (12)
             if VOWELS.contains(&g) {
                 let idx = VOWELS.iter().position(|&v| v == g).unwrap();
-                let is_long = matches!(idx, 1 | 3 | 5 | 7 | 8 | 10 | 11);
                 return Some(ProsodicUnit::Vowel(Vowel::from_index(idx)));
             }
 

--- a/tamil-seiyul-alagi/src/lib.rs
+++ b/tamil-seiyul-alagi/src/lib.rs
@@ -58,7 +58,8 @@ pub fn parse_poem(text: &str, options: ParseOptions) -> Result<ParseResult, Pars
 
 #[wasm_bindgen]
 pub fn parse_poem_wasm(text: &str) -> String {
-    let options = ParseOptions::default();
+    let mut options = ParseOptions::default();
+    options.uyir_u = true;
     match parse_poem(text, options) {
         Ok(result) => {
             serde_json::to_string(&result).unwrap_or_else(|_| "Serialization error".to_string())

--- a/tamil-seiyul-alagi/src/syllable_builder.rs
+++ b/tamil-seiyul-alagi/src/syllable_builder.rs
@@ -18,6 +18,7 @@ pub struct SyllableBuilder {
     alt_scansion: bool,
 }
 
+// TODO: fix variables names (pos, len, remaining too generic)
 impl SyllableBuilder {
     pub fn new(alt_scansion: bool) -> Self {
         Self {
@@ -36,7 +37,7 @@ impl SyllableBuilder {
 
         // Regex patterns (ordered: triplet → pair → single)
         // 110,120,11,12 -> Nirai
-        //  10, 20, 1, 2 (at the end or single letter word) -> Ner
+        //  10, 20 or 1, 2 (at the end or single letter word) -> Ner
         let re_triplet = Regex::new(r"^(110|120)").unwrap();
         let re_pair = Regex::new(r"^(11|12|10|20)").unwrap();
         let re_single = Regex::new(r"^[12]").unwrap();
@@ -46,18 +47,38 @@ impl SyllableBuilder {
         while pos < num_str.len() {
             let remaining = &num_str[pos..];
 
-            // 1. Try Triplet
             if let Some(m) = re_triplet.find(remaining) {
                 let len = m.end();
-                self.push_syllable(units, pos / 1, len, SyllableType::Nirai, "Nirai (triplet)");
+
+
+                let  is_last_syllable = self.is_last_syllable(
+                    &pos, 
+                    &len,
+                     &num_str.len()
+                );
+
+                self.push_syllable(
+                    units,
+                    pos / 1,
+                    len,
+                    SyllableType::Nirai,
+                    "Nirai (triplet)",
+                    is_last_syllable
+                );
 
                 pos += len;
                 continue;
             }
 
-            // 2. Try Pair
             if let Some(m) = re_pair.find(remaining) {
                 let len = m.end();
+
+                let  is_last_syllable = self.is_last_syllable(
+                    &pos, 
+                    &len,
+                     &num_str.len()
+                );
+
                 let pattern = &remaining[0..len];
 
                 let syllable_type = if pattern == "11" || pattern == "12" {
@@ -66,31 +87,37 @@ impl SyllableBuilder {
                     SyllableType::Ner
                 };
 
-                self.push_syllable(units, pos / 1, len, syllable_type, "Nirai/Ner (pair)");
+                self.push_syllable(
+                    units,
+                    pos / 1,
+                    len,
+                    syllable_type,
+                    "Nirai/Ner (pair)",
+                    is_last_syllable
+                );
                 pos += len;
                 continue;
             }
 
-            // 3. Single
             if re_single.is_match(remaining) {
-                let unit = &units[pos / 1];
-                let hint = if self.is_uyir_u_elision_candidate(unit) {
-                    Some("uyir-U elision".to_string())
-                } else {
-                    None
-                };
+                let len = 1;
+                
+                let  is_last_syllable = self.is_last_syllable(
+                    &pos, 
+                    &len,
+                     &num_str.len()
+                );
 
-                self.result.push(Syllable {
-                    text: unit.text().to_string(),
-                    syllable_type: SyllableType::Ner,
-                    split_hint: hint.clone(),
-                    alt_split: self.alt_scansion,
-                    rule_ref: if hint.clone().is_some() {
-                        Some("rules of letters".to_string())
-                    } else {
-                        None
-                    },
-                });
+                let syllable_type = SyllableType::Ner;
+
+                self.push_syllable(
+                    units,
+                    pos / 1,
+                    len,
+                    syllable_type,
+                    "Nirai/Ner (pair)",
+                    is_last_syllable
+                );
                 pos += 1;
             } else {
                 pos += 1; // safety
@@ -107,35 +134,55 @@ impl SyllableBuilder {
         len: usize,
         syllable_type: SyllableType,
         rule: &str,
+        is_last_syllable: bool
     ) {
         let text: String = units[start..start + len].iter().map(|u| u.text()).collect();
 
-        let hint = if self.has_uyir_u_in_range(units, start, start + len) {
+        let hint = if is_last_syllable && self.is_uyir_u(&units) {
             Some("uyir-U elision".to_string())
         } else {
             None
         };
-
         self.result.push(Syllable {
             text,
             syllable_type,
             split_hint: hint,
             alt_split: self.alt_scansion,
-            rule_ref: Some(rule.to_string()),
+            rule_ref: Some(rule.to_string())
         });
     }
 
-    fn has_uyir_u_in_range(&self, units: &[ProsodicUnit], start: usize, end: usize) -> bool {
-        units[start..end]
-            .iter()
-            .any(|u| self.is_uyir_u_elision_candidate(u))
+    //  In the whole word, last characters decide the condition
+    fn is_uyir_u(&self, units: &[ProsodicUnit]) -> bool {
+        let last_index = units.len() - 1;
+        let last_char = &units[last_index];
+
+        if let ProsodicUnit::VowelConsonant { vowel, consonant: _ } = last_char {
+            let second_last_char = &units[last_index - 1];
+    
+            if *vowel == Vowel::U {
+                let uyir_u = match second_last_char {
+                    ProsodicUnit::VowelConsonant { 
+                        vowel:_, 
+                        consonant 
+                    } => PLOSIVES_FOR_U_ELISION.contains(consonant),
+                    _ => false
+                };
+
+                return  uyir_u;
+            }
+        }
+        false
     }
 
-    fn is_uyir_u_elision_candidate(&self, unit: &ProsodicUnit) -> bool {
-        if let ProsodicUnit::VowelConsonant { vowel, consonant } = unit {
-            if *vowel == Vowel::U {
-                return PLOSIVES_FOR_U_ELISION.contains(consonant);
-            }
+    fn is_last_syllable(
+        &self,
+        current_postion: &usize, 
+        syllable_legth: &usize, 
+        unit_length: &usize
+    ) -> bool {
+        if (*current_postion + *syllable_legth) == *unit_length {
+            return  true;
         }
         false
     }

--- a/test_parser.js
+++ b/test_parser.js
@@ -4,7 +4,7 @@ import init, { parse_poem_wasm } from './tamil-seiyul-alagi/pkg/thepulimaangani_
 const testText = `ஏர்மலர் நறுங்கோதை எருத்தலைப்ப இறைஞ்சித்தன்
 வார்மலர்த் தடங்கண்ணார் வலைப்பட்டு வருந்தியவென்
 தார்வரை அகன்மார்பன் தனிமையை அறியுங்கொல்
-சீர்மலி கொடியிடை சிறந்து`;
+சீர்மலி கொடியிடை கற்றது`; // last word altered to test
 
 async function test() {
     const wasmBuffer = fs.readFileSync('./tamil-seiyul-alagi/pkg/thepulimaangani_parser_bg.wasm');


### PR DESCRIPTION
## Uyir-U elision (kurriyalukaram) check

It is easy to get last and waste time with AI when the rules and algo is tricky and too nuanced until you have confidence and prepared how to clearly ask. Decided to take the things into my own hands!

```rust

const PLOSIVES_FOR_U_ELISION: [Consonant; 5] = [
    Consonant::K,
    Consonant::Ch,
    Consonant::Tt,
    Consonant::P,
    Consonant::Rr,
];

....

   //  In the whole word, last characters decide the condition
    fn is_uyir_u(&self, units: &[ProsodicUnit]) -> bool {
        let last_index = units.len() - 1;
        let last_char = &units[last_index];

        if let ProsodicUnit::VowelConsonant { vowel, consonant: _ } = last_char {
            let second_last_char = &units[last_index - 1];
    
            if *vowel == Vowel::U {
                let uyir_u = match second_last_char {
                    ProsodicUnit::VowelConsonant { 
                        vowel:_, 
                        consonant 
                    } => PLOSIVES_FOR_U_ELISION.contains(consonant),
                    _ => false
                };

                return  uyir_u;
            }
        }
        false
    }

```
   