### PR TITLE
calm UX/UI behaviours and distractive layout shifts

### DIFF
--- a/src/components/prosody/ParseResultPanel.tsx
+++ b/src/components/prosody/ParseResultPanel.tsx
@@ -17,6 +17,8 @@ type ParseResultPanelProps = {
   live: LivePreviewState
   /** When true, auto-scrolls the live preview to the end on updates only if the user is already at the end (intersection) — avoids fighting scroll when reading higher lines. */
   pinLiveEndWhileEditing?: boolean
+  /** Explicit opt-in for follow mode; default keeps editing calm with no forced scrolling. */
+  autoFollowLivePreview?: boolean
   className?: string
 }
 
@@ -28,6 +30,7 @@ export function ParseResultPanel({
   poemText,
   live,
   pinLiveEndWhileEditing = false,
+  autoFollowLivePreview = false,
   className,
 }: ParseResultPanelProps) {
   const parsed = useMemo(() => {
@@ -53,6 +56,7 @@ export function ParseResultPanel({
         poemText={poemText}
         live={live}
         pinLiveEndWhileEditing={pinLiveEndWhileEditing}
+        autoFollowLivePreview={autoFollowLivePreview}
         hasText={hasText}
         className={className}
       />
@@ -65,6 +69,7 @@ export function ParseResultPanel({
         poemText={poemText}
         live={live}
         pinLiveEndWhileEditing={pinLiveEndWhileEditing}
+        autoFollowLivePreview={autoFollowLivePreview}
         hasText={hasText}
         className={className}
       />
@@ -84,6 +89,7 @@ export function ParseResultPanel({
           poemText={poemText}
           live={live}
           pinLiveEndWhileEditing={pinLiveEndWhileEditing}
+          autoFollowLivePreview={autoFollowLivePreview}
           hasText={hasText}
         />
       </CardContent>

--- a/src/components/prosody/PoemEditDialog.tsx
+++ b/src/components/prosody/PoemEditDialog.tsx
@@ -9,11 +9,29 @@ type PoemEditDialogProps = {
   value: string
   onChange: (v: string) => void
   onApply: () => void
-  /** e.g. changed-line syllable strip (lives under the title on narrow screens) */
-  changeStrip?: ReactNode
+  onCursorLineChange: (lineIndex: number) => void
+  /** focused current-line live preview shown above editor body */
+  liveContextRail?: ReactNode
 }
 
-export function PoemEditDialog({ open, onOpenChange, value, onChange, onApply, changeStrip }: PoemEditDialogProps) {
+function lineIndexAtCursor(value: string, cursor: number): number {
+  if (cursor <= 0) return 0
+  let count = 0
+  for (let i = 0; i < cursor && i < value.length; i++) {
+    if (value[i] === '\n') count += 1
+  }
+  return count
+}
+
+export function PoemEditDialog({
+  open,
+  onOpenChange,
+  value,
+  onChange,
+  onApply,
+  onCursorLineChange,
+  liveContextRail,
+}: PoemEditDialogProps) {
   const taRef = useRef<HTMLTextAreaElement>(null)
   const titleId = useId()
 
@@ -23,9 +41,10 @@ export function PoemEditDialog({ open, onOpenChange, value, onChange, onApply, c
       taRef.current?.focus()
       const len = taRef.current?.value.length ?? 0
       taRef.current?.setSelectionRange(len, len)
+      onCursorLineChange(lineIndexAtCursor(taRef.current?.value ?? '', len))
     })
     return () => cancelAnimationFrame(t)
-  }, [open])
+  }, [open, onCursorLineChange])
 
   useEffect(() => {
     if (!open) return
@@ -40,7 +59,18 @@ export function PoemEditDialog({ open, onOpenChange, value, onChange, onApply, c
 
   return (
     <div className="prosody-poem-editor-dock-outer">
-      <div className="prosody-poem-editor-dock-inner mx-auto w-full max-w-2xl px-3 pb-2 sm:px-4">
+      <div className="prosody-poem-editor-dock-inner relative mx-auto w-full max-w-2xl px-3 pb-2 sm:px-4">
+        {liveContextRail ? (
+          <div className="pointer-events-none absolute inset-x-0 -top-40 z-0 flex justify-center px-1 sm:px-2">
+            <div className="pointer-events-auto w-full">{liveContextRail}</div>
+          </div>
+        ) : null}
+        {liveContextRail ? (
+          <div
+            className="pointer-events-none absolute inset-x-12 -top-1 z-10 h-2 rounded-full border border-rim/35 bg-[color:color-mix(in_oklab,var(--surface-3)_72%,transparent)] shadow-inner sm:inset-x-16"
+            aria-hidden
+          />
+        ) : null}
         <section
           className="prosody-poem-editor-dock"
           role="dialog"
@@ -50,38 +80,47 @@ export function PoemEditDialog({ open, onOpenChange, value, onChange, onApply, c
           <div
             className={cn(
               'border-rim/50 text-foreground',
-              'flex max-h-[min(52vh,480px)] w-full min-w-0 flex-col overflow-hidden',
+              'flex max-h-[min(74vh,680px)] w-full min-w-0 flex-col overflow-hidden',
               'rounded-t-2xl border border-b-0 bg-[color:var(--surface-1)] p-0',
               'shadow-[0_-12px_40px_color-mix(in_oklab,var(--foreground)_6%,transparent),0_0_0_1px_color-mix(in_oklab,var(--rim)_35%,transparent)]',
             )}
             onKeyDown={(e) => e.stopPropagation()}
           >
         <div
-          className="border-rim/30 flex flex-col gap-2 border-b px-3 py-2.5 sm:px-4 sm:py-3"
+          className="border-rim/30 flex flex-col gap-1.5 border-b px-3 py-2.5 sm:px-4 sm:py-3"
           style={{
             background:
               'linear-gradient(135deg, color-mix(in oklab, var(--surface-2) 92%, var(--gem-diamond) 8%) 0%, var(--surface-1) 100%)',
           }}
         >
-          <div className="flex flex-col gap-1.5 sm:flex-row sm:items-start sm:justify-between sm:gap-3">
+          <div className="flex items-start justify-between gap-3">
             <h2 id={titleId} className="font-tamil m-0 shrink-0 text-sm font-semibold tracking-tight sm:text-base">
               Edit poem
             </h2>
-            <div className="min-w-0 sm:max-w-[min(24rem,52vw)] sm:text-right">
-              {changeStrip ? <div className="mb-1 sm:mb-0">{changeStrip}</div> : null}
-              <p className="text-muted-foreground m-0 text-[0.7rem] leading-snug sm:text-xs">
-                Scroll the page to read the live preview. Done or Esc to close.
-              </p>
-            </div>
+            <p className="text-muted-foreground m-0 text-[0.68rem] leading-snug sm:text-[0.72rem]">
+              Esc to close
+            </p>
           </div>
         </div>
-        <div className="prosody-poem-dialog-shimmer min-h-0 flex-1 px-3 pb-2 pt-3 sm:px-4">
+        <div className="prosody-poem-dialog-shimmer min-h-0 flex-1 overflow-y-auto px-3 pb-2 pt-3 sm:px-4">
           <textarea
             ref={taRef}
             value={value}
-            onChange={(e) => onChange(e.target.value)}
+            onChange={(e) => {
+              onChange(e.target.value)
+              onCursorLineChange(lineIndexAtCursor(e.target.value, e.target.selectionStart ?? 0))
+            }}
+            onClick={(e) => {
+              onCursorLineChange(lineIndexAtCursor(value, e.currentTarget.selectionStart ?? 0))
+            }}
+            onKeyUp={(e) => {
+              onCursorLineChange(lineIndexAtCursor(value, e.currentTarget.selectionStart ?? 0))
+            }}
+            onSelect={(e) => {
+              onCursorLineChange(lineIndexAtCursor(value, e.currentTarget.selectionStart ?? 0))
+            }}
             spellCheck={false}
-            className="prosody-poem-input font-tamil text-foreground max-h-[min(38vh,400px)] min-h-[10rem] w-full resize-y rounded-xl border border-rim/45 bg-[color:color-mix(in_oklab,var(--surface-2)_88%,var(--diamond-ice)_12%)] px-3 py-2.5 text-[0.875rem] leading-[1.6] shadow-inner focus-visible:border-rim/80 focus-visible:ring-2 focus-visible:ring-[color:color-mix(in_oklab,var(--gem-diamond)_30%,transparent)] focus-visible:outline-none"
+            className="prosody-poem-input font-tamil text-foreground max-h-[min(44vh,460px)] min-h-[12rem] w-full resize-y rounded-xl border border-rim/45 bg-[color:color-mix(in_oklab,var(--surface-2)_92%,var(--diamond-ice)_8%)] px-3 py-2.5 text-[0.875rem] leading-[1.6] shadow-inner focus-visible:border-rim/80 focus-visible:ring-2 focus-visible:ring-[color:color-mix(in_oklab,var(--gem-diamond)_30%,transparent)] focus-visible:outline-none"
             placeholder="Enter Tamil poem…"
           />
         </div>

--- a/src/components/prosody/PoemEditLiveContextRail.tsx
+++ b/src/components/prosody/PoemEditLiveContextRail.tsx
@@ -1,0 +1,138 @@
+import { alignSyllablesToWords } from '#/lib/alignSyllablesToWords'
+import { mapFeetToPhysicalLines, physicalPoemLines } from '#/lib/mapFeetToPhysicalLines'
+import { cn } from '#/lib/utils'
+import type { LivePreviewState } from '#/types/livePreview'
+
+const CONTEXT_RADIUS = 1
+
+type PoemEditLiveContextRailProps = {
+  poemText: string
+  live: LivePreviewState
+  focusLine: number
+  className?: string
+}
+
+function clampFocusLine(focusLine: number, lineCount: number): number {
+  if (lineCount <= 0) return 0
+  return Math.max(0, Math.min(focusLine, lineCount - 1))
+}
+
+export function PoemEditLiveContextRail({ poemText, live, focusLine, className }: PoemEditLiveContextRailProps) {
+  const lines = physicalPoemLines(poemText)
+  if (lines.length === 0) return null
+
+  const focus = clampFocusLine(focusLine, lines.length)
+  const start = Math.max(0, focus - CONTEXT_RADIUS)
+  const end = Math.min(lines.length - 1, focus + CONTEXT_RADIUS)
+  const visibleLines = lines.slice(start, end + 1)
+
+  const parsed = live.parsed
+  const feetByLine = parsed ? mapFeetToPhysicalLines(poemText, parsed.lines.flatMap((ln) => ln.feet)) : []
+  const isBusy = live.status === 'syncing' || live.status === 'pending'
+  const statusLabel =
+    live.status === 'ready'
+      ? 'Live'
+      : live.status === 'invalid'
+        ? 'சரிபார்க்கவும்'
+        : live.status === 'error'
+          ? 'பிழை'
+          : 'புதுப்பிப்பு'
+
+  return (
+    <section
+      className={cn(
+        'mx-auto w-full max-w-[min(34rem,90%)] rounded-[2px] border px-2.5 py-1.5 sm:px-3',
+        'border-[color:color-mix(in_oklab,var(--rim)_62%,var(--foreground)_12%)]',
+        'bg-[color:color-mix(in_oklab,var(--surface-1)_76%,var(--surface-2)_24%)] backdrop-blur-[1px]',
+        'shadow-[0_1px_0_color-mix(in_oklab,var(--rim)_28%,transparent),0_12px_24px_color-mix(in_oklab,var(--foreground)_14%,transparent)]',
+        className,
+      )}
+      style={{
+        backgroundImage:
+          'repeating-linear-gradient(to bottom, color-mix(in oklab, var(--rim) 18%, transparent) 0, color-mix(in oklab, var(--rim) 18%, transparent) 1px, transparent 1px, transparent 1.3rem)',
+      }}
+    >
+      <div className="mx-auto mb-1 h-1 w-10 rounded-full bg-[color:color-mix(in_oklab,var(--gem-gold)_45%,transparent)]" aria-hidden />
+      <div className="mb-1.5 flex items-center justify-between gap-2">
+        <p className="m-0 text-[0.58rem] font-semibold tracking-[0.08em] text-foreground/75">PAPER PREVIEW</p>
+        <span
+          className={cn(
+            'inline-flex items-center gap-1 rounded-full border px-1.5 py-0.5 text-[0.56rem] font-semibold tracking-wide',
+            'border-rim/45 bg-[color:color-mix(in_oklab,var(--surface-3)_82%,var(--surface-1)_18%)] text-foreground',
+          )}
+        >
+          <span
+            className={cn(
+              'inline-block size-1.5 rounded-full',
+              live.status === 'ready'
+                ? 'bg-emerald-500'
+                : live.status === 'invalid' || live.status === 'error'
+                  ? 'bg-amber-500'
+                  : 'bg-sky-500',
+              isBusy && 'animate-pulse',
+            )}
+            aria-hidden
+          />
+          {statusLabel}
+        </span>
+      </div>
+
+      <div className="max-h-36 space-y-1 overflow-hidden pr-1">
+        {visibleLines.map((lineText, localIdx) => {
+          const lineIdx = start + localIdx
+          const lineFeet = feetByLine[lineIdx] ?? []
+          const syllables = lineFeet.flatMap((f) => f.syllables)
+          const groups = alignSyllablesToWords(lineText, syllables)
+          const active = lineIdx === focus
+
+          return (
+            <div
+              key={`ctx-line-${lineIdx}-${live.layoutVersion}`}
+              className={cn(
+                'rounded-lg border px-2.5 transition-colors',
+                active ? 'py-2' : 'py-1',
+                active
+                  ? 'border-rim/70 bg-[color:color-mix(in_oklab,var(--surface-1)_88%,var(--surface-3)_12%)] shadow-sm'
+                  : 'border-rim/35 bg-[color:color-mix(in_oklab,var(--surface-2)_70%,var(--surface-3)_30%)]',
+              )}
+            >
+              <div className={cn('flex items-center gap-2', active ? 'mb-1.5' : 'mb-0.5')}>
+                <span className="text-muted-foreground text-[0.58rem] font-semibold tracking-wide">அடி {lineIdx + 1}</span>
+                <p className="font-tamil m-0 truncate text-[0.66rem] leading-[1.3] text-foreground/95">{lineText || '\u00a0'}</p>
+              </div>
+              {active && groups.length > 0 ? (
+                <div className="overflow-x-auto">
+                  <div className="inline-flex min-w-full items-end gap-1.5 pb-0.5">
+                    {groups.flatMap(({ syllables: syls }) => syls).map((syl, sylIdx) => {
+                      const isNer = syl.syllable_type === 'Ner'
+                      return (
+                        <span
+                          key={`ctx-syl-${lineIdx}-${sylIdx}-${live.layoutVersion}`}
+                          className={cn(
+                            'font-tamil inline-flex min-w-[1.2rem] flex-col items-center rounded-md border px-1 py-0.5 text-[0.6rem] leading-tight',
+                            isNer
+                              ? '[border-color:var(--syllable-ner-border)] [background-color:color-mix(in_oklab,var(--syllable-ner-bg),white_14%)] text-[color:var(--syllable-ner-text)]'
+                              : '[border-color:var(--syllable-nirai-border)] [background-color:color-mix(in_oklab,var(--syllable-nirai-bg),white_14%)] text-[color:var(--syllable-nirai-text)]',
+                          )}
+                        >
+                          <span className="max-w-[4.2rem] truncate">{syl.text}</span>
+                          <span className="font-sans text-[0.44rem] uppercase tracking-wide opacity-85">
+                            {isNer ? 'நேர்' : 'நிரை'}
+                          </span>
+                        </span>
+                      )
+                    })}
+                  </div>
+                </div>
+              ) : active ? (
+                <p className="text-muted-foreground m-0 text-[0.68rem]">பகுப்பு வரும் வரை காத்திருக்கிறது…</p>
+              ) : (
+                <div className="h-2" aria-hidden />
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </section>
+  )
+}

--- a/src/components/prosody/ProsodyLab.tsx
+++ b/src/components/prosody/ProsodyLab.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react'
 import { useSelector } from '@xstate/react'
 
 import { useProsodyActorRefFromApp } from '#/components/AppActorProvider'
@@ -6,8 +7,8 @@ import { cn } from '#/lib/utils'
 
 import { ParseResultPanel } from './ParseResultPanel'
 import { PoemAndParseCard } from './PoemAndParseCard'
-import { PoemEditChangeStrip } from './PoemEditChangeStrip'
 import { PoemEditDialog } from './PoemEditDialog'
+import { PoemEditLiveContextRail } from './PoemEditLiveContextRail'
 import { SamplesCard } from './SamplesCard'
 
 function previewDebounceMs(editorOpen: boolean) {
@@ -19,18 +20,30 @@ function previewSource(editorOpen: boolean, poemText: string, poemDraft: string)
 }
 
 export function ProsodyLab() {
+  const [editorFocusLine, setEditorFocusLine] = useState(0)
   const prosodyRef = useProsodyActorRefFromApp()
   const ctx = useSelector(prosodyRef, (s) => s?.context)
   const previewSrc = ctx ? previewSource(ctx.editorOpen, ctx.poemText, ctx.poemDraft) : ''
   const debounceMs = ctx ? previewDebounceMs(ctx.editorOpen) : 420
+  const [frozenResultLive, setFrozenResultLive] = useState(ctx?.live ?? null)
 
   useLivePreviewBridge(prosodyRef, previewSrc, debounceMs)
+
+  useEffect(() => {
+    if (!ctx) return
+    // Keep result panel stable while editing; refresh only when editor is closed.
+    if (!ctx.editorOpen) {
+      setFrozenResultLive(ctx.live)
+    }
+  }, [ctx])
 
   if (!prosodyRef || !ctx) {
     return null
   }
 
   const send = prosodyRef.send.bind(prosodyRef)
+  const resultPoemText = ctx.poemText
+  const resultLive = ctx.editorOpen ? (frozenResultLive ?? ctx.live) : ctx.live
 
   return (
     <main
@@ -66,11 +79,17 @@ export function ProsodyLab() {
           />
         </div>
 
-        <div className="min-w-0 lg:self-start">
+        <div
+          className={cn(
+            'min-w-0 lg:self-start',
+            'motion-safe:transition-[filter,opacity] motion-safe:duration-200',
+            ctx.editorOpen ? 'opacity-85 blur-[1.25px]' : null,
+          )}
+        >
           <ParseResultPanel
             result={ctx.parse.result}
-            poemText={previewSrc}
-            live={ctx.live}
+            poemText={resultPoemText}
+            live={resultLive}
             pinLiveEndWhileEditing={ctx.editorOpen}
           />
         </div>
@@ -87,9 +106,10 @@ export function ProsodyLab() {
         onApply={() => {
           send({ type: 'prosody.EDITOR.APPLY' })
         }}
-        changeStrip={
+        onCursorLineChange={setEditorFocusLine}
+        liveContextRail={
           ctx.editorOpen ? (
-            <PoemEditChangeStrip base={ctx.poemText} draft={ctx.poemDraft} live={ctx.live} />
+            <PoemEditLiveContextRail poemText={ctx.poemDraft} live={ctx.live} focusLine={editorFocusLine} />
           ) : null
         }
       />

--- a/src/components/prosody/SyllableAnnotationCell.tsx
+++ b/src/components/prosody/SyllableAnnotationCell.tsx
@@ -24,7 +24,7 @@ export function SyllableAnnotationCell({
   return (
     <span
       className={cn(
-        'font-tamil inline-flex min-w-[1.75rem] flex-col items-center rounded-lg px-2 py-1 text-center text-[0.95rem] leading-snug shadow-sm',
+        'font-tamil inline-flex min-w-[1.5rem] flex-col items-center rounded-md px-1.5 py-0.5 text-center text-[0.82rem] leading-tight shadow-sm',
         motionClass,
         'border',
         isNer
@@ -33,11 +33,11 @@ export function SyllableAnnotationCell({
       )}
       style={{ animationDelay: `${staggerMs}ms` }}
     >
-      <span className="max-w-[7rem] break-words">{text}</span>
+      <span className="max-w-[6rem] break-words">{text}</span>
       <span
         className={cn(
           'font-sans tracking-wide opacity-90',
-          'text-[0.65rem]',
+          'text-[0.56rem]',
           isNer ? 'text-[color:var(--syllable-ner-text)]' : 'text-[color:var(--syllable-nirai-text)]',
         )}
       >

--- a/src/components/prosody/SyllableLivePreview.tsx
+++ b/src/components/prosody/SyllableLivePreview.tsx
@@ -12,9 +12,16 @@ type SyllableLivePreviewProps = {
   live: LivePreviewState
   /** Tighter chrome for embedding inside the result panel */
   variant?: 'default' | 'compact'
+  /** When true, suppress pulse/shimmer motion for calm edit-focus mode. */
+  disableLiveAnimations?: boolean
 }
 
-export function SyllableLivePreview({ poemText, live, variant = 'default' }: SyllableLivePreviewProps) {
+export function SyllableLivePreview({
+  poemText,
+  live,
+  variant = 'default',
+  disableLiveAnimations = false,
+}: SyllableLivePreviewProps) {
   const compact = variant === 'compact'
   const trimmed = poemText.trim()
   if (!trimmed) return null
@@ -33,7 +40,10 @@ export function SyllableLivePreview({ poemText, live, variant = 'default' }: Syl
           <span>{compact ? 'Live' : 'Live syllables'}</span>
           {isRefreshing ? (
             <span
-              className="luxe-live-pulse-dot motion-safe:animate-pulse inline-block size-1.5 rounded-full"
+              className={cn(
+                'luxe-live-pulse-dot inline-block size-1.5 rounded-full',
+                !disableLiveAnimations && 'motion-safe:animate-pulse',
+              )}
               aria-label="Updating layout"
               title="Updating layout"
             />
@@ -96,7 +106,7 @@ export function SyllableLivePreview({ poemText, live, variant = 'default' }: Syl
                 <div
                   className={cn(
                     'text-foreground/90 rounded-md',
-                    isRefreshing && 'live-line-shimmer',
+                    isRefreshing && !disableLiveAnimations && 'live-line-shimmer',
                   )}
                 >
                   <PretextLineViewport
@@ -117,7 +127,7 @@ export function SyllableLivePreview({ poemText, live, variant = 'default' }: Syl
                       compact
                         ? 'mt-2 gap-x-4 gap-y-1.5 border-rim/45 pt-2'
                         : 'mt-3 gap-x-6 gap-y-2.5 border-rim/35 pt-3',
-                      isRefreshing && 'opacity-[0.72]',
+                      isRefreshing && !disableLiveAnimations && 'opacity-[0.72]',
                     )}
                     aria-busy={isRefreshing}
                     aria-label="Syllable preview for this line"

--- a/src/components/prosody/parseResult/LiveSyllableWithSentinel.tsx
+++ b/src/components/prosody/parseResult/LiveSyllableWithSentinel.tsx
@@ -9,6 +9,8 @@ type LiveSyllableWithSentinelProps = {
   live: LivePreviewState
   variant?: 'default' | 'compact'
   pinEnd: boolean
+  autoFollow?: boolean
+  calmWhileEditing?: boolean
 }
 
 /** Live syllable row plus sentinel for optional auto-scroll to end while editing. */
@@ -17,6 +19,8 @@ export function LiveSyllableWithSentinel({
   live,
   variant = 'compact',
   pinEnd,
+  autoFollow = false,
+  calmWhileEditing = false,
 }: LiveSyllableWithSentinelProps) {
   const sentinelRef = useRef<HTMLDivElement>(null)
   const canAutoScrollRef = useRef(true)
@@ -45,17 +49,19 @@ export function LiveSyllableWithSentinel({
   }, [])
 
   useLayoutEffect(() => {
-    if (!pinEnd) return
+    if (!pinEnd || !autoFollow) return
+    // Never force-scroll the page while the editor dialog is active.
+    if (document.querySelector('.prosody-poem-editor-dock-outer')) return
     if (!canAutoScrollRef.current) return
     const el = sentinelRef.current
     if (!el) return
     const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches
     el.scrollIntoView({ block: 'end', behavior: reduced ? 'auto' : 'smooth' })
-  }, [pinEnd, live.layoutVersion, poemText])
+  }, [pinEnd, autoFollow, live.layoutVersion, poemText])
 
   return (
     <>
-      <SyllableLivePreview poemText={poemText} live={live} variant={variant} />
+      <SyllableLivePreview poemText={poemText} live={live} variant={variant} disableLiveAnimations={calmWhileEditing} />
       <div ref={sentinelRef} className="pointer-events-none h-px w-full" aria-hidden />
     </>
   )

--- a/src/components/prosody/parseResult/ParseResultErrorState.tsx
+++ b/src/components/prosody/parseResult/ParseResultErrorState.tsx
@@ -10,6 +10,7 @@ type ParseResultErrorStateProps = {
   poemText: string
   live: LivePreviewState
   pinLiveEndWhileEditing: boolean
+  autoFollowLivePreview: boolean
   hasText: boolean
   className?: string
 }
@@ -19,6 +20,7 @@ export function ParseResultErrorState({
   poemText,
   live,
   pinLiveEndWhileEditing,
+  autoFollowLivePreview,
   hasText,
   className,
 }: ParseResultErrorStateProps) {
@@ -30,6 +32,8 @@ export function ParseResultErrorState({
             poemText={poemText}
             live={live}
             pinEnd={pinLiveEndWhileEditing}
+            autoFollow={autoFollowLivePreview}
+            calmWhileEditing={pinLiveEndWhileEditing}
           />
         ) : null}
         <div className="border-destructive/40 bg-destructive/10 rounded-lg border p-3">

--- a/src/components/prosody/parseResult/ParseResultLiveOnlyState.tsx
+++ b/src/components/prosody/parseResult/ParseResultLiveOnlyState.tsx
@@ -9,6 +9,7 @@ type ParseResultLiveOnlyStateProps = {
   poemText: string
   live: LivePreviewState
   pinLiveEndWhileEditing: boolean
+  autoFollowLivePreview: boolean
   hasText: boolean
   className?: string
 }
@@ -17,11 +18,18 @@ export function ParseResultLiveOnlyState({
   poemText,
   live,
   pinLiveEndWhileEditing,
+  autoFollowLivePreview,
   hasText,
   className,
 }: ParseResultLiveOnlyStateProps) {
   const liveBlock = hasText ? (
-    <LiveSyllableWithSentinel poemText={poemText} live={live} pinEnd={pinLiveEndWhileEditing} />
+    <LiveSyllableWithSentinel
+      poemText={poemText}
+      live={live}
+      pinEnd={pinLiveEndWhileEditing}
+      autoFollow={autoFollowLivePreview}
+      calmWhileEditing={pinLiveEndWhileEditing}
+    />
   ) : (
     <p className="text-muted-foreground m-0 text-sm">Add poem text to preview syllables.</p>
   )

--- a/src/components/prosody/parseResult/ParseResultTabsView.tsx
+++ b/src/components/prosody/parseResult/ParseResultTabsView.tsx
@@ -16,6 +16,7 @@ type ParseResultTabsViewProps = {
   poemText: string
   live: LivePreviewState
   pinLiveEndWhileEditing: boolean
+  autoFollowLivePreview: boolean
   hasText: boolean
 }
 
@@ -25,10 +26,17 @@ export function ParseResultTabsView({
   poemText,
   live,
   pinLiveEndWhileEditing,
+  autoFollowLivePreview,
   hasText,
 }: ParseResultTabsViewProps) {
   const liveBlock = hasText ? (
-    <LiveSyllableWithSentinel poemText={poemText} live={live} pinEnd={pinLiveEndWhileEditing} />
+    <LiveSyllableWithSentinel
+      poemText={poemText}
+      live={live}
+      pinEnd={pinLiveEndWhileEditing}
+      autoFollow={autoFollowLivePreview}
+      calmWhileEditing={pinLiveEndWhileEditing}
+    />
   ) : (
     <p className="text-muted-foreground m-0 text-sm">Add poem text to preview syllables.</p>
   )


### PR DESCRIPTION
When editor is focused

- Page will not jump, scroll
- Result view is blurred (so the background text don;t disract), calm, goes sleep mode (waits until edit is done). 

<img width="2078" height="1194" alt="screenshot-2026-04-27_15-27-47" src="https://github.com/user-attachments/assets/bfc4c74f-f346-4a07-99dc-577962a6f378" />

---

<img width="2082" height="1230" alt="screenshot-2026-04-27_15-28-12" src="https://github.com/user-attachments/assets/0f7b468a-e0a9-44cb-a745-6f2d6f3da59b" />
