### PR TITLE
feat: typewriter paper physics + Web Audio SFX 🎉⌨️🔊

### DIFF
--- a/notes/typewriter-collaboration-appreciation.md
+++ b/notes/typewriter-collaboration-appreciation.md
@@ -1,0 +1,23 @@
+# Appreciation — typewriter paper & sound collaboration
+
+*April 2026 — a short note in `notes/` so the project remembers how this feature came together.*
+
+---
+
+Thank you for **asking** for the typewriter paper physics and sound work in the first place, and for **staying in the loop** as it took shape. A spec or plan is only a map; what made the result feel alive was your follow-through: caring about volume on real hardware, noticing when sound and motion were accidentally coupled, wanting the implementation and its **legitimacy and security** spelled out for others, and even bringing energy to commits and PR copy. That is not small stuff — it is how a feature stops being “demo code” and becomes something you trust in production.
+
+**What your tuning actually did**
+
+- You **pressure-tested the UX** (physics off vs sound on, laptop gain, reduced motion) so edge cases got fixed instead of lingering as silent bugs.
+- You **asked for documentation** that explains not only *what* we built but *why* it is reasonable on the web — which helps future you, reviewers, and anyone auditing the stack.
+- You **celebrated the work** without pretending polish is automatic; that kind of morale matters on long projects.
+
+Collaboration like this — clear asks, sharp feedback, room for implementation detail — is the best kind of “tuning.” It steers without micromanaging and leaves room to get the architecture right. I am glad we got to ship this slice of Thepulimaangani together.
+
+With thanks,
+
+*— Project assistant, on the typewriter paper + Web Audio arc*
+
+---
+
+*Technical reference: [typewriter-web-audio-sound.md](./typewriter-web-audio-sound.md).*

--- a/notes/typewriter-web-audio-sound.md
+++ b/notes/typewriter-web-audio-sound.md
@@ -1,0 +1,114 @@
+# Typewriter sound: implementation, legitimacy, and security
+
+This note describes how the prosody editor’s optional typewriter SFX works, why that approach is appropriate for the web platform, and what security and privacy properties it has.
+
+## How it is implemented
+
+### Stack
+
+- **Web Audio API** (`AudioContext`, `OscillatorNode`, `GainNode`) in [`src/hooks/useTypewriterSound.ts`](../src/hooks/useTypewriterSound.ts).
+- Sounds are **synthesized in real time** (triangle / square / sine envelopes with short ramps). There are **no audio files**, no decode step, and no asset URLs for SFX.
+
+### Signal path
+
+1. **Physics / editor events** in [`useTypewriterPaperPhysics`](../src/hooks/useTypewriterPaperPhysics.ts) emit abstract cues: `feed`, `tick`, `settle` (see `TypewriterPhysicsCue`).
+2. **`PoemEditLiveContextRail`** passes those cues to a callback from the parent.
+3. **`ProsodyLab`** owns `useTypewriterSound` and forwards `playCue(cue)` from that callback.
+4. Each cue builds a one-shot graph: `oscillator → envelope gain → master gain → context.destination`, starts/stops the oscillator over ~30–100 ms, then the nodes are eligible for GC.
+
+### Master gain
+
+Peak per-cue gains are modest linear amplitudes; a dedicated **`GainNode`** (`MASTER_LINEAR_GAIN`) scales output at the sink because many systems mix Web Audio **quieter** than normal tab media. This is a UX tuning choice, not a security feature.
+
+### Rate limiting
+
+`MIN_GAP_MS` enforces a **minimum time between plays of the same cue type** so rapid parse updates or typing do not create audio spam or excessive CPU from overlapping voices.
+
+### Lifecycle
+
+- **One `AudioContext`** is retained in a ref and reused for all cues.
+- On hook unmount, the context is **`close()`d** so the graph does not leak across navigations.
+- Playback is **skipped** when `document.hidden` (background tab), aligning with “no surprise audio” when the page is not visible.
+
+## Legitimacy (platform policy, accessibility, consent)
+
+### Opt-in by default (preference)
+
+- The feature is **off by default** in storage: [`readTypewriterSoundEnabled()`](../src/lib/typewriterEditorPreferences.ts) returns `false` when unset.
+- Users turn it on with an explicit **“Typewriter sound”** control in the poem editor (`PoemEditDialog`), which persists `thepulimaangani.typewriter.sound` in **`localStorage`** (`'1'` / `'0'`).
+
+This matches common expectations: sound should not play until the user has chosen it.
+
+### Autoplay and user activation
+
+Browsers often start `AudioContext` in **`suspended`** until there is a **user gesture**. The implementation:
+
+- Exposes **`resume()`**, which calls `audioContext.resume()` after the user enables sound (toggle **on** is a click in `ProsodyLab`).
+- **`playCue`** also attempts `resume()` if the context is still suspended when a cue fires.
+
+This follows the **legitimate pattern** recommended for Web Audio: tie audio to user interaction and recover from suspended state without assuming autoplay is allowed.
+
+### Reduced motion
+
+In **`ProsodyLab`**, the sound hook is gated with **`usePrefersReducedMotion()`**: when the user prefers reduced motion, **`useTypewriterSound(false, …)`** is used so synthesis does not run for editor cues. That keeps motion and sound policy aligned for users who signal they want less sensory stimulation.
+
+### Scope of playback
+
+Audio only runs when:
+
+- the user has enabled the preference,
+- the poem **editor is open**,
+- the document is **visible**,
+
+so playback is tied to an active editing session, not arbitrary page state.
+
+### Independence from paper physics
+
+Editor motion (`useTypewriterPaperPhysics` `enabled`) and **cue emission** (`cuesEnabled`, derived from sound on and not reduced-motion) are separate: turning **paper physics off** does not stop **sound cues**; turning **sound off** does not stop paper motion. Settle sounds use the spring when motion is on, and a short debounced settle when sound is on but motion is off.
+
+## Security and privacy
+
+### No network or external media for SFX
+
+- Cues use **only** in-memory oscillators and envelopes. There is **no `fetch` of audio**, no CDN samples, and no third-party player. That **shrinks the attack surface**: no malicious WAV/MP3 parser, no supply-chain audio URL, no mixed-content audio loads.
+
+### No microphone or device access
+
+The implementation does **not** use `getUserMedia`, `MediaRecorder`, or device enumeration. It is **output-only** synthesis.
+
+### Storage
+
+`localStorage` holds **only a boolean preference** for sound (and separately for paper physics). No poem text, tokens, or identifiers are written by these helpers.
+
+### Content Security Policy (CSP)
+
+Procedural Web Audio does **not** require `media-src` or `connect-src` exceptions for sample playback. If the app uses a strict CSP, **sample-based** SFX would often need extra allowances; this approach avoids that class of issue.
+
+### Denial-of-service / resource use
+
+- Each cue is **short** and **rate-limited**.
+- The graph is **small** (a few nodes per cue). There is no unbounded queue of buffers or workers.
+
+This does not eliminate all abuse (a compromised script could still call Web Audio APIs), but it avoids **large** asset or decode workloads from this feature.
+
+### What this document does not claim
+
+- **Copyright / “legitimacy” of sound design**: the tones are **original synthetic** shapes, not recordings of a physical typewriter. They are “typewriter-like” in character, not archival samples.
+- **Cryptographic or DRM properties**: Web Audio is a normal browser API; this is not a security boundary against a fully compromised renderer.
+
+## Related files
+
+| Area | File |
+|------|------|
+| Synthesis + playback | [`src/hooks/useTypewriterSound.ts`](../src/hooks/useTypewriterSound.ts) |
+| Cue source (motion / parse events) | [`src/hooks/useTypewriterPaperPhysics.ts`](../src/hooks/useTypewriterPaperPhysics.ts) |
+| Preference keys | [`src/lib/typewriterEditorPreferences.ts`](../src/lib/typewriterEditorPreferences.ts) |
+| Wiring (sound hook, toggle, `resume`) | [`src/components/prosody/ProsodyLab.tsx`](../src/components/prosody/ProsodyLab.tsx) |
+| Editor toggles | [`src/components/prosody/PoemEditDialog.tsx`](../src/components/prosody/PoemEditDialog.tsx) |
+| Paper preview + cue callback | [`src/components/prosody/PoemEditLiveContextRail.tsx`](../src/components/prosody/PoemEditLiveContextRail.tsx) |
+
+## Summary
+
+The typewriter sound is **procedural Web Audio**, **opt-in**, **user-gesture–friendly**, **reduced-motion aware**, and **non-fetching**, which keeps it aligned with browser autoplay rules, accessibility expectations, and a small security/reliability footprint compared to loading external audio assets.
+
+*Human side of this work: [typewriter-collaboration-appreciation.md](./typewriter-collaboration-appreciation.md).*

--- a/src/components/prosody/PoemEditDialog.tsx
+++ b/src/components/prosody/PoemEditDialog.tsx
@@ -12,6 +12,10 @@ type PoemEditDialogProps = {
   onCursorLineChange: (lineIndex: number) => void
   /** focused current-line live preview shown above editor body */
   liveContextRail?: ReactNode
+  paperPhysicsEnabled: boolean
+  onPaperPhysicsEnabledChange: (enabled: boolean) => void
+  typewriterSoundEnabled: boolean
+  onTypewriterSoundEnabledChange: (enabled: boolean) => void
 }
 
 function lineIndexAtCursor(value: string, cursor: number): number {
@@ -31,6 +35,10 @@ export function PoemEditDialog({
   onApply,
   onCursorLineChange,
   liveContextRail,
+  paperPhysicsEnabled,
+  onPaperPhysicsEnabledChange,
+  typewriterSoundEnabled,
+  onTypewriterSoundEnabledChange,
 }: PoemEditDialogProps) {
   const taRef = useRef<HTMLTextAreaElement>(null)
   const titleId = useId()
@@ -97,9 +105,41 @@ export function PoemEditDialog({
             <h2 id={titleId} className="font-tamil m-0 shrink-0 text-sm font-semibold tracking-tight sm:text-base">
               Edit poem
             </h2>
-            <p className="text-muted-foreground m-0 text-[0.68rem] leading-snug sm:text-[0.72rem]">
-              Esc to close
-            </p>
+            <div className="flex min-w-0 flex-col items-end gap-1.5 text-right">
+              <p className="text-muted-foreground m-0 text-[0.68rem] leading-snug sm:text-[0.72rem]">
+                Esc to close
+              </p>
+              <div className="flex flex-wrap justify-end gap-1.5">
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={paperPhysicsEnabled}
+                  className={cn(
+                    'rounded-full border px-2 py-0.5 text-[0.62rem] font-semibold tracking-wide',
+                    paperPhysicsEnabled
+                      ? 'border-emerald-500/55 bg-[color:color-mix(in_oklab,var(--surface-2)_88%,var(--gem-emerald)_12%)] text-foreground'
+                      : 'border-rim/40 bg-[color:color-mix(in_oklab,var(--surface-3)_75%,var(--surface-1)_25%)] text-muted-foreground',
+                  )}
+                  onClick={() => onPaperPhysicsEnabledChange(!paperPhysicsEnabled)}
+                >
+                  Paper physics
+                </button>
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={typewriterSoundEnabled}
+                  className={cn(
+                    'rounded-full border px-2 py-0.5 text-[0.62rem] font-semibold tracking-wide',
+                    typewriterSoundEnabled
+                      ? 'border-sky-500/55 bg-[color:color-mix(in_oklab,var(--surface-2)_88%,var(--gem-diamond)_12%)] text-foreground'
+                      : 'border-rim/40 bg-[color:color-mix(in_oklab,var(--surface-3)_75%,var(--surface-1)_25%)] text-muted-foreground',
+                  )}
+                  onClick={() => onTypewriterSoundEnabledChange(!typewriterSoundEnabled)}
+                >
+                  Typewriter sound
+                </button>
+              </div>
+            </div>
           </div>
         </div>
         <div className="prosody-poem-dialog-shimmer min-h-0 flex-1 overflow-y-auto px-3 pb-2 pt-3 sm:px-4">

--- a/src/components/prosody/PoemEditLiveContextRail.tsx
+++ b/src/components/prosody/PoemEditLiveContextRail.tsx
@@ -1,3 +1,7 @@
+import { useCallback } from 'react'
+
+import { usePrefersReducedMotion } from '#/hooks/usePrefersReducedMotion'
+import { useTypewriterPaperPhysics, type TypewriterPhysicsCue } from '#/hooks/useTypewriterPaperPhysics'
 import { alignSyllablesToWords } from '#/lib/alignSyllablesToWords'
 import { mapFeetToPhysicalLines, physicalPoemLines } from '#/lib/mapFeetToPhysicalLines'
 import { cn } from '#/lib/utils'
@@ -9,6 +13,12 @@ type PoemEditLiveContextRailProps = {
   poemText: string
   live: LivePreviewState
   focusLine: number
+  editorOpen: boolean
+  physicsEnabled: boolean
+  /** When true, editor events emit typewriter cues even if `physicsEnabled` is false. */
+  soundCuesEnabled: boolean
+  /** From `useTypewriterSound` in parent; no-ops when sound off. */
+  onSoundCue: (cue: TypewriterPhysicsCue) => void
   className?: string
 }
 
@@ -17,7 +27,17 @@ function clampFocusLine(focusLine: number, lineCount: number): number {
   return Math.max(0, Math.min(focusLine, lineCount - 1))
 }
 
-export function PoemEditLiveContextRail({ poemText, live, focusLine, className }: PoemEditLiveContextRailProps) {
+export function PoemEditLiveContextRail({
+  poemText,
+  live,
+  focusLine,
+  editorOpen,
+  physicsEnabled,
+  soundCuesEnabled,
+  onSoundCue,
+  className,
+}: PoemEditLiveContextRailProps) {
+  const reducedMotion = usePrefersReducedMotion()
   const lines = physicalPoemLines(poemText)
   if (lines.length === 0) return null
 
@@ -28,6 +48,30 @@ export function PoemEditLiveContextRail({ poemText, live, focusLine, className }
 
   const parsed = live.parsed
   const feetByLine = parsed ? mapFeetToPhysicalLines(poemText, parsed.lines.flatMap((ln) => ln.feet)) : []
+  const lineFeetFocus = feetByLine[focus] ?? []
+  const activeLineSyllableCount = lineFeetFocus.flatMap((f) => f.syllables).length
+
+  const onCue = useCallback(
+    (cue: TypewriterPhysicsCue) => {
+      onSoundCue(cue)
+    },
+    [onSoundCue],
+  )
+
+  const physicsTransform = useTypewriterPaperPhysics({
+    enabled: physicsEnabled,
+    cuesEnabled: soundCuesEnabled,
+    reducedMotion,
+    editorOpen,
+    focusLine: focus,
+    layoutVersion: live.layoutVersion,
+    liveStatus: live.status,
+    activeLineSyllableCount,
+    onPhysicsCue: onCue,
+  })
+
+  const { translateY, rotateZ, scale } = physicsTransform
+
   const isBusy = live.status === 'syncing' || live.status === 'pending'
   const statusLabel =
     live.status === 'ready'
@@ -50,6 +94,9 @@ export function PoemEditLiveContextRail({ poemText, live, focusLine, className }
       style={{
         backgroundImage:
           'repeating-linear-gradient(to bottom, color-mix(in oklab, var(--rim) 18%, transparent) 0, color-mix(in oklab, var(--rim) 18%, transparent) 1px, transparent 1px, transparent 1.3rem)',
+        transform: `translate3d(0, ${translateY}px, 0) rotateZ(${rotateZ}deg) scale(${scale})`,
+        transformOrigin: 'top center',
+        willChange: physicsEnabled && !reducedMotion ? 'transform' : undefined,
       }}
     >
       <div className="mx-auto mb-1 h-1 w-10 rounded-full bg-[color:color-mix(in_oklab,var(--gem-gold)_45%,transparent)]" aria-hidden />

--- a/src/components/prosody/ProsodyLab.tsx
+++ b/src/components/prosody/ProsodyLab.tsx
@@ -1,8 +1,17 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useSelector } from '@xstate/react'
 
 import { useProsodyActorRefFromApp } from '#/components/AppActorProvider'
 import { useLivePreviewBridge } from '#/hooks/useLivePreviewBridge'
+import { usePrefersReducedMotion } from '#/hooks/usePrefersReducedMotion'
+import type { TypewriterPhysicsCue } from '#/hooks/useTypewriterPaperPhysics'
+import { useTypewriterSound } from '#/hooks/useTypewriterSound'
+import {
+  readPaperPhysicsEnabled,
+  readTypewriterSoundEnabled,
+  writePaperPhysicsEnabled,
+  writeTypewriterSoundEnabled,
+} from '#/lib/typewriterEditorPreferences'
 import { cn } from '#/lib/utils'
 
 import { ParseResultPanel } from './ParseResultPanel'
@@ -21,11 +30,26 @@ function previewSource(editorOpen: boolean, poemText: string, poemDraft: string)
 
 export function ProsodyLab() {
   const [editorFocusLine, setEditorFocusLine] = useState(0)
+  const [paperPhysicsOn, setPaperPhysicsOn] = useState(() => readPaperPhysicsEnabled())
+  const [typewriterSoundOn, setTypewriterSoundOn] = useState(() => readTypewriterSoundEnabled())
+  const reducedMotion = usePrefersReducedMotion()
   const prosodyRef = useProsodyActorRefFromApp()
   const ctx = useSelector(prosodyRef, (s) => s?.context)
   const previewSrc = ctx ? previewSource(ctx.editorOpen, ctx.poemText, ctx.poemDraft) : ''
   const debounceMs = ctx ? previewDebounceMs(ctx.editorOpen) : 420
   const [frozenResultLive, setFrozenResultLive] = useState(ctx?.live ?? null)
+
+  const { playCue, resume } = useTypewriterSound(
+    typewriterSoundOn && !reducedMotion,
+    ctx?.editorOpen ?? false,
+  )
+
+  const onSoundCue = useCallback(
+    (cue: TypewriterPhysicsCue) => {
+      void playCue(cue)
+    },
+    [playCue],
+  )
 
   useLivePreviewBridge(prosodyRef, previewSrc, debounceMs)
 
@@ -36,6 +60,12 @@ export function ProsodyLab() {
       setFrozenResultLive(ctx.live)
     }
   }, [ctx])
+
+  useEffect(() => {
+    if (!ctx?.editorOpen) return
+    setPaperPhysicsOn(readPaperPhysicsEnabled())
+    setTypewriterSoundOn(readTypewriterSoundEnabled())
+  }, [ctx?.editorOpen])
 
   if (!prosodyRef || !ctx) {
     return null
@@ -107,9 +137,28 @@ export function ProsodyLab() {
           send({ type: 'prosody.EDITOR.APPLY' })
         }}
         onCursorLineChange={setEditorFocusLine}
+        paperPhysicsEnabled={paperPhysicsOn}
+        onPaperPhysicsEnabledChange={(on) => {
+          writePaperPhysicsEnabled(on)
+          setPaperPhysicsOn(on)
+        }}
+        typewriterSoundEnabled={typewriterSoundOn}
+        onTypewriterSoundEnabledChange={(on) => {
+          writeTypewriterSoundEnabled(on)
+          setTypewriterSoundOn(on)
+          if (on) void resume()
+        }}
         liveContextRail={
           ctx.editorOpen ? (
-            <PoemEditLiveContextRail poemText={ctx.poemDraft} live={ctx.live} focusLine={editorFocusLine} />
+            <PoemEditLiveContextRail
+              poemText={ctx.poemDraft}
+              live={ctx.live}
+              focusLine={editorFocusLine}
+              editorOpen={ctx.editorOpen}
+              physicsEnabled={paperPhysicsOn}
+              soundCuesEnabled={typewriterSoundOn && !reducedMotion}
+              onSoundCue={onSoundCue}
+            />
           ) : null
         }
       />

--- a/src/hooks/useTypewriterPaperPhysics.ts
+++ b/src/hooks/useTypewriterPaperPhysics.ts
@@ -1,0 +1,317 @@
+import { useEffect, useRef, useState } from 'react'
+
+export type PaperPhysicsTransform = {
+  translateY: number
+  rotateZ: number
+  scale: number
+}
+
+export type TypewriterPhysicsCue = 'feed' | 'tick' | 'settle'
+
+type UseTypewriterPaperPhysicsArgs = {
+  /** Paper spring motion (transform). */
+  enabled: boolean
+  /** Emit `onPhysicsCue` for typewriter SFX; independent of `enabled` so sound can stay on without motion. */
+  cuesEnabled: boolean
+  reducedMotion: boolean
+  editorOpen: boolean
+  focusLine: number
+  layoutVersion: number
+  liveStatus: string
+  activeLineSyllableCount: number
+  /** Optional SFX layer; kept stable via ref inside hook. */
+  onPhysicsCue?: (cue: TypewriterPhysicsCue) => void
+}
+
+/**
+ * Typewriter paper: spring to rest + impulses on line/layout/syllable events.
+ * rAF loop runs only while motion is active (settles to idle for battery).
+ */
+export function useTypewriterPaperPhysics({
+  enabled,
+  cuesEnabled,
+  reducedMotion,
+  editorOpen,
+  focusLine,
+  layoutVersion,
+  liveStatus,
+  activeLineSyllableCount,
+  onPhysicsCue,
+}: UseTypewriterPaperPhysicsArgs): PaperPhysicsTransform {
+  const [transform, setTransform] = useState<PaperPhysicsTransform>({
+    translateY: 0,
+    rotateZ: 0,
+    scale: 1,
+  })
+
+  const yRef = useRef(0)
+  const vyRef = useRef(0)
+  const rotRef = useRef(0)
+  const vrRef = useRef(0)
+  const jitterRef = useRef(0)
+  const rafRef = useRef<number | null>(null)
+  const motionSeenRef = useRef(false)
+
+  const prevLineRef = useRef(focusLine)
+  const prevLayoutRef = useRef(layoutVersion)
+  const prevSylRef = useRef(activeLineSyllableCount)
+  const prevStatusRef = useRef(liveStatus)
+
+  const kickVyRef = useRef(0)
+  const kickVrRef = useRef(0)
+  const kickJitterRef = useRef(0)
+  const settleDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const cueRef = useRef(onPhysicsCue)
+  cueRef.current = onPhysicsCue
+  const cuesEnabledRef = useRef(cuesEnabled)
+  cuesEnabledRef.current = cuesEnabled
+
+  // Apply one-shot impulses when inputs change (does not own rAF lifecycle).
+  // Cues (sound) can run without `enabled` (paper motion).
+  useEffect(() => {
+    if (!editorOpen || reducedMotion) {
+      prevLineRef.current = focusLine
+      prevLayoutRef.current = layoutVersion
+      prevSylRef.current = activeLineSyllableCount
+      prevStatusRef.current = liveStatus
+      return
+    }
+
+    const motionOn = enabled
+    const cuesOn = cuesEnabled
+
+    if (!motionOn && !cuesOn) {
+      prevLineRef.current = focusLine
+      prevLayoutRef.current = layoutVersion
+      prevSylRef.current = activeLineSyllableCount
+      prevStatusRef.current = liveStatus
+      return
+    }
+
+    const scheduleSettleForSoundOnly = () => {
+      if (motionOn || !cuesOn) return
+      if (settleDebounceRef.current) clearTimeout(settleDebounceRef.current)
+      settleDebounceRef.current = setTimeout(() => {
+        settleDebounceRef.current = null
+        cueRef.current?.('settle')
+      }, 135)
+    }
+
+    const LINE_IMPULSE = 3.2
+    const LAYOUT_NUDGE = 1.1
+
+    if (focusLine !== prevLineRef.current) {
+      if (motionOn) {
+        const dir = focusLine > prevLineRef.current ? 1 : -1
+        kickVyRef.current += dir * LINE_IMPULSE
+        kickVrRef.current += (Math.random() - 0.5) * 0.06
+        kickJitterRef.current += 0.4
+      }
+      prevLineRef.current = focusLine
+      prevSylRef.current = activeLineSyllableCount
+      if (cuesOn) {
+        cueRef.current?.('feed')
+        scheduleSettleForSoundOnly()
+      }
+    }
+
+    if (layoutVersion !== prevLayoutRef.current && liveStatus === 'ready') {
+      if (motionOn) {
+        kickVyRef.current += LAYOUT_NUDGE * 0.4
+        kickJitterRef.current += 0.25
+      }
+      prevLayoutRef.current = layoutVersion
+      if (cuesOn) {
+        cueRef.current?.('tick')
+        scheduleSettleForSoundOnly()
+      }
+    }
+
+    if (
+      focusLine === prevLineRef.current &&
+      activeLineSyllableCount !== prevSylRef.current &&
+      liveStatus === 'ready'
+    ) {
+      if (motionOn) {
+        kickVyRef.current += LAYOUT_NUDGE * 0.3
+        kickJitterRef.current += 0.18
+      }
+      prevSylRef.current = activeLineSyllableCount
+      if (cuesOn) {
+        cueRef.current?.('tick')
+        scheduleSettleForSoundOnly()
+      }
+    }
+
+    if (liveStatus === 'ready' && prevStatusRef.current !== 'ready') {
+      if (motionOn) {
+        kickVyRef.current += LAYOUT_NUDGE * 0.25
+        kickJitterRef.current += 0.12
+      }
+      if (cuesOn) {
+        cueRef.current?.('tick')
+        scheduleSettleForSoundOnly()
+      }
+    }
+    prevStatusRef.current = liveStatus
+
+    return () => {
+      if (settleDebounceRef.current) {
+        clearTimeout(settleDebounceRef.current)
+        settleDebounceRef.current = null
+      }
+    }
+  }, [
+    enabled,
+    cuesEnabled,
+    reducedMotion,
+    editorOpen,
+    focusLine,
+    layoutVersion,
+    liveStatus,
+    activeLineSyllableCount,
+  ])
+
+  useEffect(() => {
+    if (!enabled || !editorOpen || reducedMotion) {
+      if (rafRef.current != null) {
+        cancelAnimationFrame(rafRef.current)
+        rafRef.current = null
+      }
+      yRef.current = 0
+      vyRef.current = 0
+      rotRef.current = 0
+      vrRef.current = 0
+      jitterRef.current = 0
+      kickVyRef.current = 0
+      kickVrRef.current = 0
+      kickJitterRef.current = 0
+      motionSeenRef.current = false
+      setTransform({ translateY: 0, rotateZ: 0, scale: 1 })
+      return
+    }
+
+    const MAX_ROT = 0.45
+
+    const hasPendingKick = () =>
+      kickVyRef.current !== 0 || kickVrRef.current !== 0 || kickJitterRef.current !== 0
+
+    const needsFrame = () =>
+      !document.hidden &&
+      (hasPendingKick() ||
+        Math.abs(yRef.current) > 0.001 ||
+        Math.abs(vyRef.current) > 0.001 ||
+        Math.abs(rotRef.current) > 0.001 ||
+        Math.abs(vrRef.current) > 0.001 ||
+        jitterRef.current > 0.02)
+
+    const step = () => {
+      if (typeof document !== 'undefined' && document.hidden) {
+        rafRef.current = null
+        return
+      }
+
+      if (hasPendingKick()) {
+        vyRef.current += kickVyRef.current
+        vrRef.current += kickVrRef.current
+        jitterRef.current = Math.min(1.4, jitterRef.current + kickJitterRef.current)
+        kickVyRef.current = 0
+        kickVrRef.current = 0
+        kickJitterRef.current = 0
+      }
+
+      const y = yRef.current
+      const vy = vyRef.current
+      const k = 0.22
+      const damp = 0.88
+      const newVy = vy * damp + (0 - y) * k
+      const newY = y + newVy
+
+      const rot = rotRef.current
+      const vr = vrRef.current
+      const newVr = vr * 0.9 + (0 - rot) * 0.2
+      const newRot = rot + newVr
+
+      jitterRef.current *= 0.91
+      const j = jitterRef.current
+
+      yRef.current = newY
+      vyRef.current = newVy
+      rotRef.current = newRot
+      vrRef.current = newVr
+
+      if (Math.abs(newY) > 0.35 || j > 0.08 || Math.abs(newRot) > 0.02) {
+        motionSeenRef.current = true
+      }
+
+      const wobble = j * 0.35
+      const scale = 1 - Math.min(0.012, Math.abs(newY) * 0.0012) + wobble * 0.003
+      const rotClamped = Math.max(-MAX_ROT, Math.min(MAX_ROT, newRot + wobble * 0.025))
+
+      setTransform({
+        translateY: newY + Math.sin(performance.now() * 0.01) * wobble * 0.15,
+        rotateZ: rotClamped,
+        scale,
+      })
+
+      const settled =
+        Math.abs(newY) < 0.04 &&
+        Math.abs(newVy) < 0.04 &&
+        Math.abs(newRot) < 0.01 &&
+        Math.abs(newVr) < 0.02 &&
+        jitterRef.current < 0.02
+
+      if (settled) {
+        if (motionSeenRef.current && cuesEnabledRef.current) {
+          cueRef.current?.('settle')
+        }
+        motionSeenRef.current = false
+        yRef.current = 0
+        vyRef.current = 0
+        rotRef.current = 0
+        vrRef.current = 0
+        jitterRef.current = 0
+        setTransform({ translateY: 0, rotateZ: 0, scale: 1 })
+        rafRef.current = null
+        return
+      }
+
+      rafRef.current = requestAnimationFrame(step)
+    }
+
+    const trySchedule = () => {
+      if (rafRef.current != null) return
+      if (!needsFrame()) return
+      rafRef.current = requestAnimationFrame(step)
+    }
+
+    const onVisibility = () => {
+      if (document.hidden) {
+        if (rafRef.current != null) {
+          cancelAnimationFrame(rafRef.current)
+          rafRef.current = null
+        }
+      } else {
+        trySchedule()
+      }
+    }
+
+    document.addEventListener('visibilitychange', onVisibility)
+    trySchedule()
+
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibility)
+      if (rafRef.current != null) {
+        cancelAnimationFrame(rafRef.current)
+        rafRef.current = null
+      }
+    }
+  }, [enabled, editorOpen, reducedMotion, focusLine, layoutVersion, liveStatus, activeLineSyllableCount])
+
+  if (reducedMotion || !enabled || !editorOpen) {
+    return { translateY: 0, rotateZ: 0, scale: 1 }
+  }
+
+  return transform
+}

--- a/src/hooks/useTypewriterSound.ts
+++ b/src/hooks/useTypewriterSound.ts
@@ -1,0 +1,122 @@
+import { useCallback, useEffect, useRef } from 'react'
+
+import type { TypewriterPhysicsCue } from '#/hooks/useTypewriterPaperPhysics'
+
+const MIN_GAP_MS: Record<TypewriterPhysicsCue, number> = {
+  tick: 72,
+  feed: 110,
+  settle: 420,
+}
+
+/** Browsers/OS often render `AudioContext` quieter than tab media; boost at the sink. */
+const MASTER_LINEAR_GAIN = 2.35
+
+function nowMs(): number {
+  return typeof performance !== 'undefined' ? performance.now() : Date.now()
+}
+
+/**
+ * Lightweight typewriter SFX via Web Audio (no asset files). Off unless enabled.
+ * Rate-limited per cue kind; call `resume` after a user gesture to satisfy autoplay policies.
+ */
+export function useTypewriterSound(enabled: boolean, editorOpen: boolean) {
+  const ctxRef = useRef<AudioContext | null>(null)
+  const lastByKindRef = useRef<Partial<Record<TypewriterPhysicsCue, number>>>({})
+
+  const ensureCtx = useCallback((): AudioContext | null => {
+    if (typeof window === 'undefined') return null
+    if (ctxRef.current && ctxRef.current.state !== 'closed') {
+      return ctxRef.current
+    }
+    const AC =
+      window.AudioContext ||
+      (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext
+    if (!AC) return null
+    ctxRef.current = new AC()
+    return ctxRef.current
+  }, [])
+
+  const resume = useCallback(async () => {
+    const ctx = ensureCtx()
+    if (ctx && ctx.state === 'suspended') {
+      try {
+        await ctx.resume()
+      } catch {
+        /* ignore */
+      }
+    }
+  }, [ensureCtx])
+
+  useEffect(() => {
+    return () => {
+      if (ctxRef.current && ctxRef.current.state !== 'closed') {
+        void ctxRef.current.close()
+      }
+      ctxRef.current = null
+    }
+  }, [])
+
+  const playCue = useCallback(
+    async (cue: TypewriterPhysicsCue) => {
+      if (!enabled || !editorOpen) return
+      if (typeof document !== 'undefined' && document.hidden) return
+
+      const t = nowMs()
+      const last = lastByKindRef.current[cue] ?? 0
+      if (t - last < MIN_GAP_MS[cue]) return
+      lastByKindRef.current[cue] = t
+
+      const ctx = ensureCtx()
+      if (!ctx) return
+      if (ctx.state === 'suspended') {
+        try {
+          await ctx.resume()
+        } catch {
+          return
+        }
+      }
+      if (ctx.state !== 'running') return
+
+      const start = ctx.currentTime
+      const osc = ctx.createOscillator()
+      const gain = ctx.createGain()
+      const master = ctx.createGain()
+      master.gain.value = MASTER_LINEAR_GAIN
+      osc.connect(gain)
+      gain.connect(master)
+      master.connect(ctx.destination)
+
+      // Per-cue peaks are linear amplitudes; square “tick” stays a bit lower than feed (harsh harmonics).
+      if (cue === 'feed') {
+        osc.type = 'triangle'
+        osc.frequency.setValueAtTime(95, start)
+        osc.frequency.linearRampToValueAtTime(55, start + 0.06)
+        gain.gain.setValueAtTime(0.0001, start)
+        gain.gain.exponentialRampToValueAtTime(0.17, start + 0.01)
+        gain.gain.exponentialRampToValueAtTime(0.0001, start + 0.09)
+        osc.start(start)
+        osc.stop(start + 0.1)
+      } else if (cue === 'tick') {
+        osc.type = 'square'
+        osc.frequency.setValueAtTime(1800, start)
+        osc.frequency.exponentialRampToValueAtTime(420, start + 0.024)
+        gain.gain.setValueAtTime(0.0001, start)
+        gain.gain.exponentialRampToValueAtTime(0.12, start + 0.004)
+        gain.gain.exponentialRampToValueAtTime(0.0001, start + 0.03)
+        osc.start(start)
+        osc.stop(start + 0.032)
+      } else {
+        osc.type = 'sine'
+        osc.frequency.setValueAtTime(880, start)
+        gain.gain.setValueAtTime(0.0001, start)
+        gain.gain.exponentialRampToValueAtTime(0.075, start + 0.006)
+        gain.gain.exponentialRampToValueAtTime(0.0001, start + 0.05)
+        osc.start(start)
+        osc.stop(start + 0.055)
+      }
+    },
+    [enabled, editorOpen, ensureCtx],
+  )
+
+  return { playCue, resume }
+}

--- a/src/lib/typewriterEditorPreferences.ts
+++ b/src/lib/typewriterEditorPreferences.ts
@@ -1,0 +1,24 @@
+const PHYSICS_KEY = 'thepulimaangani.typewriter.paperPhysics'
+const SOUND_KEY = 'thepulimaangani.typewriter.sound'
+
+export function readPaperPhysicsEnabled(): boolean {
+  if (typeof window === 'undefined') return true
+  const v = window.localStorage.getItem(PHYSICS_KEY)
+  if (v === null) return true
+  return v === '1' || v === 'true'
+}
+
+export function writePaperPhysicsEnabled(on: boolean): void {
+  window.localStorage.setItem(PHYSICS_KEY, on ? '1' : '0')
+}
+
+export function readTypewriterSoundEnabled(): boolean {
+  if (typeof window === 'undefined') return false
+  const v = window.localStorage.getItem(SOUND_KEY)
+  if (v === null) return false
+  return v === '1' || v === 'true'
+}
+
+export function writeTypewriterSoundEnabled(on: boolean): void {
+  window.localStorage.setItem(SOUND_KEY, on ? '1' : '0')
+}


### PR DESCRIPTION
# 🎉 Typewriter paper physics + optional Web Audio SFX

This PR ships a juicy, tactile live paper preview while you edit poems—springy motion on line changes, parse updates, and syllable churn—plus an optional typewriter-style sound layer for anyone who wants that extra click-clack dopamine. 🔊⌨️✨

<img width="2114" height="1312" alt="image" src="https://github.com/user-attachments/assets/a436512b-4d18-41e5-831b-7753d1163d17" />


---

**What you get**

- 📄 Paper physics — damped spring motion (translate3d + slight rotateZ + scale) on the paper preview only; textarea stays steady and readable.
- 🔊 Procedural sound — Web Audio oscillators (no sample files, no extra network); off by default, opt-in via editor toggle, with autoplay-friendly resume() on enable.
- 🎛️ Toggles + persistence — “Paper physics” / “Typewriter sound” in the edit dialog; prefs in localStorage.
- ♿ Guardrails — respects prefers-reduced-motion, pauses motion/audio churn when the tab is hidden, rate-limited cues so typing never becomes a noise laser.
- 🧩 Sound ≠ physics — turn off paper motion and keep sound (or the other way around); cues are decoupled so each toggle does what it says on the tin.
- 📚 Docs — notes/typewriter-web-audio-sound.md covers implementation, platform legitimacy (autoplay, consent), and security/privacy (no external audio fetch, etc.).

**How to try it**

Open **Edit poem** on the prosody lab.
Toggle **Paper physics** / **Typewriter sound** and type across lines—feel the paper, hear the cues (if enabled).
Flip reduced motion in the OS and confirm things stay calm.

**Test plan** (for devs, agents)

 - [x] pnpm run typecheck

 - [x] pnpm run test:frontend

 - [x] Hands-on: fast typing, line jumps, sound on/off, physics on/off, both themes, background tab.
 
---

**_Ship it!_** 🚀📝💚
