### PR TITLE
✨ Big refactor — hierarchical prosody + honest syllable/word UI

### DIFF
--- a/src/components/prosody/PoemEditLiveContextRail.tsx
+++ b/src/components/prosody/PoemEditLiveContextRail.tsx
@@ -2,8 +2,8 @@ import { useCallback } from 'react'
 
 import { usePrefersReducedMotion } from '#/hooks/usePrefersReducedMotion'
 import { useTypewriterPaperPhysics, type TypewriterPhysicsCue } from '#/hooks/useTypewriterPaperPhysics'
-import { alignSyllablesToWords } from '#/lib/alignSyllablesToWords'
-import { mapFeetToPhysicalLines, physicalPoemLines } from '#/lib/mapFeetToPhysicalLines'
+import { feetPerPhysicalLine, groupsFromFeet } from '#/lib/parserFeetLayout'
+import { physicalPoemLines } from '#/lib/mapFeetToPhysicalLines'
 import { cn } from '#/lib/utils'
 import type { LivePreviewState } from '#/types/livePreview'
 
@@ -47,7 +47,7 @@ export function PoemEditLiveContextRail({
   const visibleLines = hasLines ? lines.slice(start, end + 1) : []
 
   const parsed = live.parsed
-  const feetByLine = parsed ? mapFeetToPhysicalLines(poemText, parsed.lines.flatMap((ln) => ln.feet)) : []
+  const feetByLine = parsed ? feetPerPhysicalLine(parsed, poemText) : []
   const lineFeetFocus = feetByLine[focus] ?? []
   const activeLineSyllableCount = lineFeetFocus.flatMap((f) => f.syllables).length
 
@@ -130,8 +130,7 @@ export function PoemEditLiveContextRail({
         {visibleLines.map((lineText, localIdx) => {
           const lineIdx = start + localIdx
           const lineFeet = feetByLine[lineIdx] ?? []
-          const syllables = lineFeet.flatMap((f) => f.syllables)
-          const groups = alignSyllablesToWords(lineText, syllables)
+          const groups = groupsFromFeet(lineFeet)
           const active = lineIdx === focus
 
           return (

--- a/src/components/prosody/SyllableLivePreview.tsx
+++ b/src/components/prosody/SyllableLivePreview.tsx
@@ -1,6 +1,6 @@
 import type { LivePreviewState } from '#/types/livePreview'
-import { alignSyllablesToWords } from '#/lib/alignSyllablesToWords'
-import { mapFeetToPhysicalLines, physicalPoemLines } from '#/lib/mapFeetToPhysicalLines'
+import { feetPerPhysicalLine, groupsFromFeet } from '#/lib/parserFeetLayout'
+import { physicalPoemLines } from '#/lib/mapFeetToPhysicalLines'
 import { cn } from '#/lib/utils'
 
 import { PretextLineViewport } from './PretextLineViewport'
@@ -29,9 +29,8 @@ export function SyllableLivePreview({
   const parsed = live.parsed
   const isRefreshing = live.status === 'syncing' || live.status === 'pending'
 
-  const feet = parsed ? parsed.lines.flatMap((ln) => ln.feet) : []
   const physicalLines = physicalPoemLines(poemText)
-  const feetByLine = parsed ? mapFeetToPhysicalLines(poemText, feet) : []
+  const feetByLine = parsed ? feetPerPhysicalLine(parsed, poemText) : []
 
   return (
     <div className={cn(compact ? 'space-y-2' : 'space-y-3')}>
@@ -68,9 +67,7 @@ export function SyllableLivePreview({
       </div>
       {!compact ? (
         <p className="text-muted-foreground m-0 max-w-xl text-xs leading-relaxed">
-          Each source line is one row (no column wrap); the row below colours each syllable (நேர் / நிரை)
-          without extra labels. Across several lines, grouping is still approximate until the engine emits
-          line-scoped feet.
+          Each source line is one row; syllables are grouped by **linguistic word** (same grouping as the WASM parser).
         </p>
       ) : null}
 
@@ -89,8 +86,7 @@ export function SyllableLivePreview({
         >
           {physicalLines.map((lineText, lineIdx) => {
             const lineFeet = feetByLine[lineIdx] ?? []
-            const syllables = lineFeet.flatMap((f) => f.syllables)
-            const groups = alignSyllablesToWords(lineText, syllables)
+            const groups = groupsFromFeet(lineFeet)
             const pretextSource = lineText.length === 0 ? '\u00a0' : lineText
 
             let stagger = 0

--- a/src/components/prosody/displayLabels.ts
+++ b/src/components/prosody/displayLabels.ts
@@ -6,13 +6,42 @@ const lineClassMap: Record<string, string> = {
   neTilaTi: 'நெடிலடி',
 }
 
+/** Logic layer `foot_type` = hyphenated Ner/Nirai pattern; values = Tamil · simple Latin. */
 const footTypeMap: Record<string, string> = {
-  tEmA: 'தேமா',
-  puLimA: 'புளிமா',
-  kUviLa_m: 'கூவிளம்',
-  karuviLa_m: 'கருவிளம்',
-  mA: 'மா',
-  viLa_m: 'விளம்',
+  // 1 acai
+  Ner: 'மா (ma)',
+  Nirai: 'விளம் (vilam)',
+  // 2 acai
+  'Ner-Ner': 'தேமா (thema)',
+  'Ner-Nirai': 'கூவிளம் (ku vilam)',
+  'Nirai-Ner': 'புளிமா (pulima)',
+  'Nirai-Nirai': 'கருவிளம் (karuvilam)',
+  // 3 acai
+  'Ner-Ner-Ner': 'தேமாங்காய் (thema kangay)',
+  'Ner-Ner-Nirai': 'தேமாகவி (thema kavi)',
+  'Ner-Nirai-Ner': 'கூவிளங்காய் (ku vilam kangay)',
+  'Ner-Nirai-Nirai': 'கூவிளகவி (ku vilam kavi)',
+  'Nirai-Ner-Ner': 'புளிமாங்காய் (pulima kangay)',
+  'Nirai-Ner-Nirai': 'புளிமாகவி (pulima kavi)',
+  'Nirai-Nirai-Ner': 'கருவிளங்காய் (karuvilam kangay)',
+  'Nirai-Nirai-Nirai': 'கருவிளகவி (karuvilam kavi)',
+  // 4 acai
+  'Ner-Ner-Ner-Ner': 'தேமாந்தப்பூ (thema thanthapuu)',
+  'Ner-Ner-Ner-Nirai': 'தேமாந்தநிழல் (thema thanth nizhal)',
+  'Ner-Ner-Nirai-Ner': 'தேமாரும்பூ (thema arumpuu)',
+  'Ner-Ner-Nirai-Nirai': 'தேமாருநிழல் (thema aru nizhal)',
+  'Ner-Nirai-Ner-Ner': 'கூவிளந்தப்பூ (ku vilam thanthapuu)',
+  'Ner-Nirai-Ner-Nirai': 'கூவிளந்தநிழல் (ku vilam thanth nizhal)',
+  'Ner-Nirai-Nirai-Ner': 'கூவிளரும்பூ (ku vilam arumpuu)',
+  'Ner-Nirai-Nirai-Nirai': 'கூவிளருநிழல் (ku vilam aru nizhal)',
+  'Nirai-Ner-Ner-Ner': 'புளிமாந்தப்பூ (pulima thanthapuu)',
+  'Nirai-Ner-Ner-Nirai': 'புளிமாந்தநிழல் (pulima thanth nizhal)',
+  'Nirai-Ner-Nirai-Ner': 'புளிமாரும்பூ (pulima arumpuu)',
+  'Nirai-Ner-Nirai-Nirai': 'புளிமாருநிழல் (pulima aru nizhal)',
+  'Nirai-Nirai-Ner-Ner': 'கருவிளந்தப்பூ (karuvilam thanthapuu)',
+  'Nirai-Nirai-Ner-Nirai': 'கருவிளந்தநிழல் (karuvilam thanth nizhal)',
+  'Nirai-Nirai-Nirai-Ner': 'கருவிளரும்பூ (karuvilam arumpuu)',
+  'Nirai-Nirai-Nirai-Nirai': 'கருவிளருநிழல் (karuvilam aru nizhal)',
 }
 
 export function getLineClassDisplay(lineClass: string): string {

--- a/src/lib/__tests__/adaptWasmParseJson.test.ts
+++ b/src/lib/__tests__/adaptWasmParseJson.test.ts
@@ -12,7 +12,7 @@ describe('adaptWasmJsonToParsedPoem', () => {
       syllables: [{ text: 'அஃ', syllable_type: 'Ner' }],
       feet: [
         {
-          foot_type: 'tEmA',
+          foot_type: 'Ner-Ner',
           syllables: [
             { text: 'அஃ', syllable_type: 'Ner' },
             { text: 'கு', syllable_type: 'Nirai' },

--- a/src/lib/__tests__/mapFeetToPhysicalLines.test.ts
+++ b/src/lib/__tests__/mapFeetToPhysicalLines.test.ts
@@ -4,7 +4,7 @@ import { mapFeetToPhysicalLines, physicalPoemLines } from '#/lib/mapFeetToPhysic
 import type { ParsedFoot } from '#/types/parsedPoem'
 
 const mkFoot = (id: string): ParsedFoot => ({
-  foot_type: 'tEmA',
+  foot_type: 'Ner-Ner',
   syllables: [{ text: id, syllable_type: 'Ner' }],
 })
 

--- a/src/lib/__tests__/parserFeetLayout.test.ts
+++ b/src/lib/__tests__/parserFeetLayout.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+
+import { feetPerPhysicalLine, groupsFromFeet } from '#/lib/parserFeetLayout'
+import type { ParsedPoem } from '#/types/parsedPoem'
+
+function poem(lines: ParsedPoem['lines']): ParsedPoem {
+  return {
+    original_text: '',
+    metre_type: '—',
+    letter_count: 0,
+    vikalpa_count: 0,
+    syllables: [],
+    lines,
+  }
+}
+
+describe('feetPerPhysicalLine', () => {
+  it('uses structured lines when count matches physical lines', () => {
+    const p = poem([
+      {
+        line_class: '—',
+        feet: [
+          {
+            foot_type: 'Ner-Ner',
+            syllables: [{ text: 'ab', syllable_type: 'Ner' }],
+          },
+        ],
+      },
+      {
+        line_class: '—',
+        feet: [
+          {
+            foot_type: 'Nirai',
+            syllables: [{ text: 'cd', syllable_type: 'Nirai' }],
+          },
+        ],
+      },
+    ])
+    const text = 'first line\nsecond'
+    const buckets = feetPerPhysicalLine(p, text)
+    expect(buckets).toHaveLength(2)
+    expect(buckets[0]![0]!.syllables[0]!.text).toBe('ab')
+    expect(buckets[1]![0]!.syllables[0]!.text).toBe('cd')
+  })
+})
+
+describe('groupsFromFeet', () => {
+  it('one group per foot with concatenated word label', () => {
+    const g = groupsFromFeet([
+      {
+        foot_type: 'Ner-Nirai',
+        syllables: [
+          { text: 'நண்', syllable_type: 'Ner' },
+          { text: 'ணு', syllable_type: 'Nirai' },
+        ],
+      },
+      {
+        foot_type: 'Ner-Nirai',
+        syllables: [
+          { text: 'வார்', syllable_type: 'Ner' },
+          { text: 'வினை', syllable_type: 'Nirai' },
+        ],
+      },
+    ])
+    expect(g).toHaveLength(2)
+    expect(g[0]!.word).toBe('நண்ணு')
+    expect(g[1]!.word).toBe('வார்வினை')
+  })
+})

--- a/src/lib/adaptWasmParseJson.ts
+++ b/src/lib/adaptWasmParseJson.ts
@@ -12,7 +12,15 @@ function normalizeSyllable(raw: unknown): ParsedSyllable | null {
   if (typeof s.text !== 'string') return null
   const st = s.syllable_type
   const syllable_type = typeof st === 'string' ? st : 'Nirai'
-  return { text: s.text, syllable_type }
+  const line_index = typeof s.line_index === 'number' ? s.line_index : undefined
+  const word_index_in_line =
+    typeof s.word_index_in_line === 'number' ? s.word_index_in_line : undefined
+  return {
+    text: s.text,
+    syllable_type,
+    ...(line_index !== undefined ? { line_index } : {}),
+    ...(word_index_in_line !== undefined ? { word_index_in_line } : {}),
+  }
 }
 
 function normalizeFeet(raw: unknown[]): ParsedFoot[] {

--- a/src/lib/parserFeetLayout.ts
+++ b/src/lib/parserFeetLayout.ts
@@ -1,0 +1,28 @@
+import type { ParsedFoot, ParsedPoem } from '#/types/parsedPoem'
+
+import { mapFeetToPhysicalLines, physicalPoemLines } from '#/lib/mapFeetToPhysicalLines'
+
+/**
+ * Feet per physical editor line: prefer WASM `parsed.lines` when line counts match;
+ * otherwise fall back to character-weighted {@link mapFeetToPhysicalLines}.
+ */
+export function feetPerPhysicalLine(parsed: ParsedPoem | null, poemText: string): ParsedFoot[][] {
+  const physical = physicalPoemLines(poemText)
+  if (physical.length === 0) return []
+
+  const structured = parsed?.lines ?? []
+  if (structured.length === physical.length) {
+    return structured.map((ln) => ln.feet)
+  }
+
+  const flat = structured.flatMap((ln) => ln.feet)
+  return mapFeetToPhysicalLines(poemText, flat.length > 0 ? flat : [])
+}
+
+/** One UI group per **linguistic word** (one WASM foot). Syllables stay parser order. */
+export function groupsFromFeet(lineFeet: ParsedFoot[]): { word: string; syllables: ParsedFoot['syllables'] }[] {
+  return lineFeet.map((foot) => ({
+    word: foot.syllables.map((s) => s.text).join(''),
+    syllables: foot.syllables,
+  }))
+}

--- a/src/lib/poemLineDiff.ts
+++ b/src/lib/poemLineDiff.ts
@@ -1,5 +1,6 @@
-import { mapFeetToPhysicalLines, physicalPoemLines } from '#/lib/mapFeetToPhysicalLines'
-import type { ParsedFoot, ParsedPoem } from '#/types/parsedPoem'
+import { feetPerPhysicalLine } from '#/lib/parserFeetLayout'
+import { physicalPoemLines } from '#/lib/mapFeetToPhysicalLines'
+import type { ParsedPoem } from '#/types/parsedPoem'
 
 /** Raw newline split (preserves structure even when a line is empty). */
 export function normLines(s: string): string[] {
@@ -66,15 +67,9 @@ export function getChangedLineIndices(base: string, draft: string): number[] {
   return out
 }
 
-function allFeet(parsed: ParsedPoem): ParsedFoot[] {
-  return parsed.lines.flatMap((l) => l.feet)
-}
-
-/** Syllable count per physical line (matches live preview / WASM layout heuristic). */
 export function syllableCountsPerPhysicalLine(poemText: string, parsed: ParsedPoem): number[] {
   const lines = physicalPoemLines(poemText)
   if (lines.length === 0) return []
-  const feet = allFeet(parsed)
-  const perLine = mapFeetToPhysicalLines(poemText, feet)
+  const perLine = feetPerPhysicalLine(parsed, poemText)
   return perLine.map((lineFeet) => lineFeet.reduce((n, f) => n + f.syllables.length, 0))
 }

--- a/src/types/parsedPoem.ts
+++ b/src/types/parsedPoem.ts
@@ -1,6 +1,10 @@
 export interface ParsedSyllable {
   text: string
   syllable_type: string
+  /** From WASM when present: physical line index for this syllable. */
+  line_index?: number
+  /** From WASM when present: linguistic word index within that line. */
+  word_index_in_line?: number
 }
 
 export interface ParsedFoot {

--- a/tamil-seiyul-alagi/QUALITY_CRAP_BASELINE.md
+++ b/tamil-seiyul-alagi/QUALITY_CRAP_BASELINE.md
@@ -9,10 +9,11 @@ Later, CI can compute and validate the same baseline automatically.
 
 ## Baseline Snapshot
 
-- Date: 2026-04-26
-- Scope: `tamil-seiyul-alagi/src/*` parser core
-- Baseline method: manual CRAP-style score
-- Total baseline score: 23
+- **Date:** 2026-04-29 _(updated; prior snapshot 2026-04-26 below)_
+- **Scope:** `tamil-seiyul-alagi/src/*` parser core
+- **Baseline method:** manual CRAP-style score
+- **Total baseline score (sum of hotspot rows):** 33  
+  _(Interpret as aggregate risk surface; not a single function CRAP metric.)_
 
 Scoring formula:
 
@@ -36,11 +37,27 @@ Interpretation:
 
 | Module / Function | Complexity Rank | Untested Rank | Score | Risk | Why |
 |---|---:|---:|---:|---|---|
-| `src/metre.rs::detect_metre` | 3 | 3 | 9 | critical | Current heuristic misclassifies known Aciriyappaa fixture. |
-| `src/syllable_builder.rs::build` | 3 | 2 | 6 | high | Ordered regex branching with boundary-sensitive behavior. |
-| `src/lib.rs::parse_poem` | 2 | 2 | 4 | moderate | Pipeline fan-out can silently break output structure. |
-| `src/linkage.rs::analyze_linkage` | 2 | 2 | 4 | moderate | Placeholder constant linkage classification and validity. |
-| `src/foot.rs::group_into_feet` | 2 | 2 | 4 | moderate | Placeholder chunking/cyclic naming not rule-driven yet. |
+| `src/metre.rs::detect_metre` | 3 | 3 | 9 | critical | Heuristic still misclassifies known Asiriyappaa fixture; metre hypotheses naive. |
+| `src/lib.rs::parse_poem` | 3 | 2 | 6 | high | Orchestrates word segmentation, feet, `PoemNode` tree, linkage; integration surface grew. |
+| `src/syllable_builder.rs::build_inner` | 2 | 2 | 4 | moderate | Ordered regex scan per **linguistic word**; unit tests cover common paths. |
+| `src/word_scope.rs::segment_syllables_from_normalized` | 2 | 2 | 4 | moderate | Line/word tokenization drives all downstream syllables; integration-heavy. |
+| `src/linkage.rs::foot_positions_for_poem` + `analyze_linkage` | 2 | 2 | 4 | moderate | Positions correct; `linkage_type` / validity still largely placeholder. |
+| `src/poem_tree.rs::build_poem_tree` + `linguistic_words_per_line` | 2 | 2 | 4 | moderate | Tree + parallel linguistic grouping; must stay aligned with `ParseResult.lines`. |
+| `src/foot.rs::group_into_feet_with_ranges` | 2 | 1 | 2 | low | One foot per linguistic word + `foot_pattern()` Ner-Nirai string; covered by foot tests. |
+
+**Dropped from prior table (superseded):**
+
+- `foot.rs` placeholder **chunks of 3** — replaced by linguistic-word grouping + pattern strings.
+- `syllable_builder.rs::build` as monolithic stream — replaced by per-word `build_word_segment` / `build_inner`.
+
+---
+
+## Changelog
+
+| Date | Note |
+|------|------|
+| 2026-04-26 | Initial baseline (chunk feet, flat syllable stream). Total hotspot sum was 27 if all rows summed (doc previously said 23). |
+| 2026-04-29 | Great refactor: `word_scope`, `poem_tree`, `FootPosition` linkage, Ner-Nirai `foot_type` patterns, per-word syllable segmentation. Hotspots and total refreshed. |
 
 ---
 
@@ -64,4 +81,3 @@ When CI is ready:
 3. Compute CRAP-style scores automatically.
 4. Compare CI scores against this baseline and report deltas.
 5. Start in report-only mode; enforce thresholds after stable baseline history.
-

--- a/tamil-seiyul-alagi/src/foot.rs
+++ b/tamil-seiyul-alagi/src/foot.rs
@@ -1,5 +1,8 @@
+use std::ops::Range;
+
 use serde::{Deserialize, Serialize};
 
+use crate::foot_pattern::foot_pattern;
 use crate::syllable::Syllable;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -8,19 +11,101 @@ pub struct Foot {
     pub foot_type: String,
 }
 
+/// A foot together with the syllable index range it covers in the poem-wide syllable list.
+#[derive(Debug, Clone)]
+pub struct FootPlacement {
+    pub foot: Foot,
+    pub syllable_range: Range<usize>,
+}
+
 pub fn group_into_feet(syllables: &[Syllable]) -> Vec<Foot> {
-    // Simplified version - improve with full WordType map later
-    syllables
-        .chunks(3)
-        .enumerate()
-        .map(|(i, chunk)| Foot {
-            syllables: chunk.to_vec(),
-            foot_type: match i % 4 {
-                0 => "tEmA".to_string(),
-                1 => "puLimA".to_string(),
-                2 => "kUviLa_m".to_string(),
-                _ => "karuviLa_m".to_string(),
-            },
-        })
+    group_into_feet_with_ranges(syllables)
+        .into_iter()
+        .map(|p| p.foot)
         .collect()
+}
+
+/// One **foot** per **linguistic word** (same `line_index` + `word_index_in_line` on syllables).
+/// Syllables must appear in poem order from [`crate::word_scope::segment_syllables_from_normalized`].
+pub fn group_into_feet_with_ranges(syllables: &[Syllable]) -> Vec<FootPlacement> {
+    if syllables.is_empty() {
+        return vec![];
+    }
+
+    let mut placements = Vec::new();
+    let mut run_start = 0usize;
+    let mut current_key = word_key(&syllables[0]);
+
+    for i in 1..=syllables.len() {
+        let flush = i == syllables.len()
+            || word_key(&syllables[i]) != current_key;
+
+        if flush {
+            let chunk = &syllables[run_start..i];
+            placements.push(FootPlacement {
+                foot: Foot {
+                    syllables: chunk.to_vec(),
+                    foot_type: foot_pattern(chunk),
+                },
+                syllable_range: run_start..i,
+            });
+            if i < syllables.len() {
+                current_key = word_key(&syllables[i]);
+                run_start = i;
+            }
+        }
+    }
+
+    placements
+}
+
+fn word_key(s: &Syllable) -> (usize, usize) {
+    (s.line_index, s.word_index_in_line)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::syllable::{Syllable, SyllableType};
+
+    fn s(
+        text: &str,
+        st: SyllableType,
+        line_index: usize,
+        word_index_in_line: usize,
+    ) -> Syllable {
+        Syllable {
+            text: text.into(),
+            syllable_type: st,
+            split_hint: None,
+            alt_split: false,
+            rule_ref: None,
+            line_index,
+            word_index_in_line,
+        }
+    }
+
+    #[test]
+    fn ner_ner_word_is_tema() {
+        let syllables = vec![
+            s("a", SyllableType::Ner, 0, 0),
+            s("b", SyllableType::Ner, 0, 0),
+        ];
+        let p = group_into_feet_with_ranges(&syllables);
+        assert_eq!(p.len(), 1);
+        assert_eq!(p[0].foot.foot_type, "Ner-Ner");
+    }
+
+    #[test]
+    fn one_foot_per_linguistic_word_not_chunks_of_three() {
+        let syllables = vec![
+            s("a", SyllableType::Ner, 0, 0),
+            s("b", SyllableType::Ner, 0, 0),
+            s("c", SyllableType::Ner, 0, 1),
+        ];
+        let p = group_into_feet_with_ranges(&syllables);
+        assert_eq!(p.len(), 2);
+        assert_eq!(p[0].syllable_range, 0..2);
+        assert_eq!(p[1].syllable_range, 2..3);
+    }
 }

--- a/tamil-seiyul-alagi/src/foot_pattern.rs
+++ b/tamil-seiyul-alagi/src/foot_pattern.rs
@@ -1,0 +1,62 @@
+//! Foot pattern as readable Ner/Nirai sequences (logic layer — no transliteration codes).
+
+use crate::syllable::{Syllable, SyllableType};
+
+fn token(st: SyllableType) -> &'static str {
+    match st {
+        SyllableType::Ner => "Ner",
+        SyllableType::Nirai => "Nirai",
+    }
+}
+
+/// Hyphenated pattern for one linguistic word’s syllables, e.g. `Ner-Ner`, `Nirai-Ner-Nirai`.
+/// Empty slice yields empty string; callers may treat that as invalid.
+pub fn foot_pattern(syllables: &[Syllable]) -> String {
+    syllables
+        .iter()
+        .map(|s| token(s.syllable_type))
+        .collect::<Vec<_>>()
+        .join("-")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::syllable::SyllableType;
+
+    fn dummy(st: SyllableType) -> Syllable {
+        Syllable {
+            text: "x".into(),
+            syllable_type: st,
+            split_hint: None,
+            alt_split: false,
+            rule_ref: None,
+            line_index: 0,
+            word_index_in_line: 0,
+        }
+    }
+
+    #[test]
+    fn formats_two_acai() {
+        assert_eq!(
+            foot_pattern(&[dummy(SyllableType::Ner), dummy(SyllableType::Ner)]),
+            "Ner-Ner"
+        );
+        assert_eq!(
+            foot_pattern(&[dummy(SyllableType::Nirai), dummy(SyllableType::Nirai)]),
+            "Nirai-Nirai"
+        );
+    }
+
+    #[test]
+    fn formats_three_nirai() {
+        assert_eq!(
+            foot_pattern(&[
+                dummy(SyllableType::Nirai),
+                dummy(SyllableType::Nirai),
+                dummy(SyllableType::Nirai),
+            ]),
+            "Nirai-Nirai-Nirai"
+        );
+    }
+}

--- a/tamil-seiyul-alagi/src/letter.rs
+++ b/tamil-seiyul-alagi/src/letter.rs
@@ -1,6 +1,7 @@
 //! Letter classification and conversion to ProsodicUnit using the official Tamil character matrix.
 
 use serde::{Deserialize, Serialize};
+use unicode_segmentation::UnicodeSegmentation;
 
 use crate::prosodic_unit::{Consonant, ProsodicUnit, Vowel};
 use crate::tamil_chars::{generate_uyirmei_matrix, PURE_CONSONANTS, VOWELS};
@@ -92,18 +93,39 @@ impl Consonant {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum LetterType {
+    Uyir,
+    Mei,
+    Uyirmei,
+    Aaytham,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Letter {
     pub text: String,
     pub letter_type: LetterType,
     pub matra: u8,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub enum LetterType {
-    Uyir,
-    Mei,
-    Uyirmei,
-    Aaytham,
+/// Grapheme letters under one syllable's surface text (prosodic units in order).
+pub fn letters_from_syllable_text(text: &str) -> Vec<Letter> {
+    let graphemes: Vec<&str> = text.graphemes(true).collect();
+    let units = to_prosodic_units(&graphemes);
+    units.iter().map(letter_from_prosodic_unit).collect()
+}
+
+fn letter_from_prosodic_unit(unit: &ProsodicUnit) -> Letter {
+    Letter {
+        text: unit.text(),
+        letter_type: match unit {
+            ProsodicUnit::Vowel(_) => LetterType::Uyir,
+            ProsodicUnit::Consonant(_) => LetterType::Mei,
+            ProsodicUnit::VowelConsonant { .. } => LetterType::Uyirmei,
+            ProsodicUnit::Aaytham => LetterType::Aaytham,
+            ProsodicUnit::ConsonantCluster(_) => LetterType::Mei,
+        },
+        matra: unit.matra(),
+    }
 }
 
 #[cfg(test)]

--- a/tamil-seiyul-alagi/src/lib.rs
+++ b/tamil-seiyul-alagi/src/lib.rs
@@ -1,8 +1,11 @@
 mod error;
 mod foot;
+mod foot_pattern;
 mod letter;
+mod line_scope;
 mod linkage;
 mod metre;
+mod poem_tree;
 mod presentation;
 mod prosodic_sequence;
 mod prosodic_unit;
@@ -10,20 +13,26 @@ mod syllable;
 mod syllable_builder;
 mod tamil_chars;
 mod types;
+mod word_scope;
 
 pub use prosodic_sequence::ProsodicSequence;
 
 use wasm_bindgen::prelude::*;
 
 pub use error::ParseError;
-pub use foot::Foot;
+pub use foot::{Foot, FootPlacement};
+pub use foot_pattern::foot_pattern;
 pub use letter::Letter;
-pub use linkage::{Linkage, LinkageType, Talai, TalaiType};
+pub use linkage::{FootPosition, Linkage, LinkageType, Talai, TalaiType};
 pub use metre::MetreType;
+pub use poem_tree::{
+    LetterLayer, LetterNode, LinguisticWordNode, LineLayer, PoemLayer, PoemLineNode, PoemNode,
+    SyllableLayer, SyllableNode, WordLayer, WordNode,
+};
 pub use prosodic_unit::{Consonant, ProsodicUnit, Vowel};
 pub use syllable::{Syllable, SyllableType};
 pub use syllable_builder::SyllableBuilder;
-pub use types::{MetreHypothesis, ParseOptions, ParseResult, RuleId};
+pub use types::{flat_lines_from_poem, MetreHypothesis, ParseOptions, ParseResult, RuleId};
 
 use unicode_segmentation::UnicodeSegmentation;
 
@@ -38,10 +47,21 @@ pub fn parse_poem(text: &str, options: ParseOptions) -> Result<ParseResult, Pars
     let graphemes: Vec<&str> = normalized.graphemes(true).collect();
     let normalized_clone = normalized.clone();
 
-    let units = letter::to_prosodic_units(&graphemes);
-    let syllables = SyllableBuilder::new(options.alt_scansion).build(&units);
-    let feet = foot::group_into_feet(&syllables);
-    let linkage = linkage::analyze_linkage(&feet);
+    let syllables = word_scope::segment_syllables_from_normalized(&normalized_clone, options.alt_scansion);
+    let syllable_lines = line_scope::syllable_line_indices(&normalized_clone, &syllables)
+        .unwrap_or_else(|| vec![0; syllables.len()]);
+    let foot_placements = foot::group_into_feet_with_ranges(&syllables);
+    let feet: Vec<Foot> = foot_placements.iter().map(|p| p.foot.clone()).collect();
+    let foot_positions = linkage::foot_positions_for_poem(&foot_placements, &syllable_lines);
+    let linkage = linkage::analyze_linkage(&foot_positions);
+    let poem = poem_tree::build_poem_tree(
+        normalized_clone.clone(),
+        &syllables,
+        &foot_positions,
+        &foot_placements,
+        linkage.clone(),
+    );
+    let lines = types::flat_lines_from_poem(&poem);
     let metre_hypotheses = metre::detect_metre_hypotheses(&feet, &linkage, options.no_detect);
     let metre = metre_hypotheses.first().map(|h| h.metre_type.clone());
 
@@ -50,11 +70,12 @@ pub fn parse_poem(text: &str, options: ParseOptions) -> Result<ParseResult, Pars
         normalized_text: normalized_clone,
         letter_count: graphemes.len(),
         vikalpa_count: if options.alt_scansion { 1 } else { 0 },
+        poem,
         syllables,
         feet,
         talai: linkage.clone(),
         linkage,
-        lines: vec![],
+        lines,
         metre_type: metre,
         confidence: metre_hypotheses.first().map_or(0, |h| h.aggregate_score),
         provenance: metre_hypotheses
@@ -150,6 +171,66 @@ mod tests {
         assert!(json.get("syllables").and_then(|v| v.as_array()).is_some());
         assert!(json.get("feet").and_then(|v| v.as_array()).is_some());
         assert!(json.get("linkage").and_then(|v| v.as_array()).is_some());
+        assert!(json.get("poem").is_some());
+
+        let poem = &result.poem;
+        assert!(!poem.lines.is_empty(), "hierarchical poem should have at least one line");
+        let tree_syllable_count: usize = poem
+            .lines
+            .iter()
+            .flat_map(|ln| ln.words.iter())
+            .flat_map(|w| w.syllables.iter())
+            .count();
+        assert_eq!(tree_syllable_count, result.syllables.len());
+        assert_eq!(result.lines.len(), poem.lines.len());
+
+        let lw0 = &poem.lines[0].linguistic_words;
+        assert!(
+            lw0.len() >= 2,
+            "first line should have multiple linguistic words from spaces"
+        );
+        assert!(
+            lw0.iter().all(|w| !w.syllables.is_empty()),
+            "each linguistic word should have syllables"
+        );
+    }
+
+    #[test]
+    fn linkage_carries_line_and_word_position_across_lines() {
+        let mut options = ParseOptions::default();
+        options.alt_scansion = true;
+        options.no_detect = true;
+        let poem = "கற்றது! மொழிந்தது.\nஅறிந்தவர் சொல்லும் வழி;";
+        let result = parse_poem(poem, options).expect("parse");
+
+        assert!(
+            result.feet.len() >= 3,
+            "sample should yield multiple feet; got {}",
+            result.feet.len()
+        );
+        let boundary = result
+            .linkage
+            .iter()
+            .find(|l| l.from.line_index != l.to.line_index);
+        assert!(
+            boundary.is_some(),
+            "expected at least one linkage crossing lines; got {:?}",
+            result.linkage
+        );
+        let b = boundary.unwrap();
+        assert!(b.from.line_index < b.to.line_index);
+        // Destination foot is the first word on its physical line (starts after prior line text).
+        assert_eq!(b.to.word_index_in_line, 0);
+        let first = serde_json::to_value(&result.linkage[0]).expect("json");
+        assert!(json_has_foot_position_fields(&first));
+    }
+
+    fn json_has_foot_position_fields(linkage_json: &serde_json::Value) -> bool {
+        linkage_json.get("from").map_or(false, |from| {
+            from.get("line_index").is_some()
+                && from.get("word_index_in_line").is_some()
+                && from.get("foot_index").is_some()
+        })
     }
 
     #[test]

--- a/tamil-seiyul-alagi/src/line_scope.rs
+++ b/tamil-seiyul-alagi/src/line_scope.rs
@@ -1,0 +1,171 @@
+//! Map syllables to physical line indices using normalized poem text (whitespace stripped).
+
+use crate::syllable::Syllable;
+
+/// One byte range `[start, end)` in the compact (whitespace-free) character stream per logical line.
+#[derive(Debug, Clone)]
+struct LineByteSpan {
+    line_index: usize,
+    start: usize,
+    end: usize,
+}
+
+/// Build compact text (no whitespace) and per-line byte spans within it.
+fn compact_text_and_line_spans(normalized_text: &str) -> (String, Vec<LineByteSpan>) {
+    let compact_full: String = normalized_text.chars().filter(|c| !c.is_whitespace()).collect();
+    let mut spans = Vec::new();
+    let mut offset = 0usize;
+    for (line_index, line) in normalized_text.lines().enumerate() {
+        let compact_line: String = line.chars().filter(|c| !c.is_whitespace()).collect();
+        let len = compact_line.len();
+        spans.push(LineByteSpan {
+            line_index,
+            start: offset,
+            end: offset + len,
+        });
+        offset += len;
+    }
+    debug_assert_eq!(offset, compact_full.len());
+    (compact_full, spans)
+}
+
+fn line_index_for_compact_byte(pos: usize, spans: &[LineByteSpan]) -> usize {
+    for span in spans {
+        if pos >= span.start && pos < span.end {
+            return span.line_index;
+        }
+    }
+    // Fallback: last line if we landed exactly at end (should not happen for valid pos)
+    spans.last().map(|s| s.line_index).unwrap_or(0)
+}
+
+/// Returns `syllable_line_indices[i]` = physical line index (0-based) for `syllables[i]`.
+/// `normalized_text` must be the same string used to derive `syllables` (after normalization).
+pub fn syllable_line_indices(normalized_text: &str, syllables: &[Syllable]) -> Option<Vec<usize>> {
+    let (compact_full, spans) = compact_text_and_line_spans(normalized_text);
+    if syllables.is_empty() {
+        return Some(vec![]);
+    }
+    let mut out = Vec::with_capacity(syllables.len());
+    let mut pos = 0usize;
+    for syllable in syllables {
+        let t = syllable.text.as_str();
+        if pos + t.len() > compact_full.len() {
+            return None;
+        }
+        if compact_full.get(pos..pos + t.len()) != Some(t) {
+            return None;
+        }
+        out.push(line_index_for_compact_byte(pos, &spans));
+        pos += t.len();
+    }
+    if pos != compact_full.len() {
+        return None;
+    }
+    Some(out)
+}
+
+/// Line index for a foot from its syllables: uses the **first** syllable's line (poetry feet should
+/// not span lines; if they did, this anchors to the foot's starting line).
+pub fn foot_line_index(syllable_lines: &[usize], foot_syllable_range: std::ops::Range<usize>) -> usize {
+    syllable_lines
+        .get(foot_syllable_range.start)
+        .copied()
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::syllable::{Syllable, SyllableType};
+
+    #[test]
+    fn syllable_lines_match_multiline_compact_stream() {
+        let normalized = "கற்றது  மொழிந்தது \nஅறிந்தவர் சொல்லும் வழி ";
+        let syllables = vec![
+            Syllable {
+                text: "கற்".into(),
+                syllable_type: SyllableType::Ner,
+                split_hint: None,
+                alt_split: false,
+                rule_ref: None,
+                line_index: 0,
+                word_index_in_line: 0,
+            },
+            Syllable {
+                text: "றது".into(),
+                syllable_type: SyllableType::Nirai,
+                split_hint: None,
+                alt_split: false,
+                rule_ref: None,
+                line_index: 0,
+                word_index_in_line: 0,
+            },
+            Syllable {
+                text: "மொழிந்".into(),
+                syllable_type: SyllableType::Nirai,
+                split_hint: None,
+                alt_split: false,
+                rule_ref: None,
+                line_index: 0,
+                word_index_in_line: 1,
+            },
+            Syllable {
+                text: "தது".into(),
+                syllable_type: SyllableType::Nirai,
+                split_hint: None,
+                alt_split: false,
+                rule_ref: None,
+                line_index: 0,
+                word_index_in_line: 1,
+            },
+            Syllable {
+                text: "அறிந்".into(),
+                syllable_type: SyllableType::Nirai,
+                split_hint: None,
+                alt_split: false,
+                rule_ref: None,
+                line_index: 1,
+                word_index_in_line: 0,
+            },
+            Syllable {
+                text: "தவர்".into(),
+                syllable_type: SyllableType::Nirai,
+                split_hint: None,
+                alt_split: false,
+                rule_ref: None,
+                line_index: 1,
+                word_index_in_line: 0,
+            },
+            Syllable {
+                text: "சொல்".into(),
+                syllable_type: SyllableType::Ner,
+                split_hint: None,
+                alt_split: false,
+                rule_ref: None,
+                line_index: 1,
+                word_index_in_line: 1,
+            },
+            Syllable {
+                text: "லும்".into(),
+                syllable_type: SyllableType::Nirai,
+                split_hint: None,
+                alt_split: false,
+                rule_ref: None,
+                line_index: 1,
+                word_index_in_line: 1,
+            },
+            Syllable {
+                text: "வழி".into(),
+                syllable_type: SyllableType::Nirai,
+                split_hint: None,
+                alt_split: false,
+                rule_ref: None,
+                line_index: 1,
+                word_index_in_line: 2,
+            },
+        ];
+        let lines = syllable_line_indices(normalized, &syllables).expect("mapping");
+        assert_eq!(lines, vec![0, 0, 0, 0, 1, 1, 1, 1, 1]);
+    }
+}

--- a/tamil-seiyul-alagi/src/linkage.rs
+++ b/tamil-seiyul-alagi/src/linkage.rs
@@ -1,30 +1,76 @@
 use serde::{Deserialize, Serialize};
 
-use crate::foot::Foot;
+use crate::foot::FootPlacement;
+use crate::line_scope::foot_line_index;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum LinkageType {
     VenTalai,
     AsiriyaTalai,
     Other(String),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// Where a foot (word) sits in the poem: global index, line, and position within that line.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FootPosition {
+    /// Index of this foot in the poem-wide `feet` list (0-based).
+    pub foot_index: usize,
+    /// Physical line in the normalized poem (0-based).
+    pub line_index: usize,
+    /// 0-based index among feet that **start** on `line_index`.
+    pub word_index_in_line: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Linkage {
     pub from_foot: usize,
     pub to_foot: usize,
+    pub from: FootPosition,
+    pub to: FootPosition,
     pub linkage_type: LinkageType,
     pub is_valid: bool,
 }
 
-pub fn analyze_linkage(feet: &[Foot]) -> Vec<Linkage> {
-    feet.windows(2)
+/// Assign each foot a physical line and its index among feet on that line (word position).
+pub fn foot_positions_for_poem(
+    placements: &[FootPlacement],
+    syllable_lines: &[usize],
+) -> Vec<FootPosition> {
+    let mut word_count_per_line: Vec<usize> = Vec::new();
+    placements
+        .iter()
         .enumerate()
-        .map(|(i, _)| Linkage {
-            from_foot: i,
-            to_foot: i + 1,
-            linkage_type: LinkageType::VenTalai,
-            is_valid: true,
+        .map(|(foot_index, placement)| {
+            let line_index = foot_line_index(syllable_lines, placement.syllable_range.clone());
+            if line_index >= word_count_per_line.len() {
+                word_count_per_line.resize(line_index + 1, 0);
+            }
+            let word_index_in_line = word_count_per_line[line_index];
+            word_count_per_line[line_index] += 1;
+            FootPosition {
+                foot_index,
+                line_index,
+                word_index_in_line,
+            }
+        })
+        .collect()
+}
+
+/// Linkage between each consecutive pair of feet in poem order (may cross line boundaries).
+pub fn analyze_linkage(foot_positions: &[FootPosition]) -> Vec<Linkage> {
+    foot_positions
+        .windows(2)
+        .map(|w| {
+            let from = w[0].clone();
+            let to = w[1].clone();
+            Linkage {
+                from_foot: from.foot_index,
+                to_foot: to.foot_index,
+                from,
+                to,
+                linkage_type: LinkageType::VenTalai,
+                is_valid: true,
+            }
         })
         .collect()
 }
@@ -33,6 +79,6 @@ pub fn analyze_linkage(feet: &[Foot]) -> Vec<Linkage> {
 pub type Talai = Linkage;
 pub type TalaiType = LinkageType;
 
-pub fn analyze_talai(feet: &[Foot]) -> Vec<Talai> {
-    analyze_linkage(feet)
+pub fn analyze_talai(foot_positions: &[FootPosition]) -> Vec<Talai> {
+    analyze_linkage(foot_positions)
 }

--- a/tamil-seiyul-alagi/src/poem_tree.rs
+++ b/tamil-seiyul-alagi/src/poem_tree.rs
@@ -1,0 +1,279 @@
+//! Hierarchical poem model: Poem → Line → Word (foot) → Syllable → Letter (acai).
+//!
+//! Trait contracts describe what each layer exposes upward for traversal and batch tooling.
+
+use serde::{Deserialize, Serialize};
+
+use crate::letter::{letters_from_syllable_text, Letter};
+use crate::linkage::Linkage;
+use crate::syllable::{Syllable, SyllableType};
+
+/// Reference index within the flattened poem-wide syllable array (`PoemNode.syllables_flat`).
+pub type SyllableGlobalIndex = usize;
+
+/// Leaf: one grapheme cluster under a syllable (எழுத்து / prosodic surface segment).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LetterNode {
+    pub inner: Letter,
+}
+
+impl LetterLayer for LetterNode {}
+
+/// Syllable node with nested letters.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyllableNode {
+    pub inner: Syllable,
+    pub letters: Vec<LetterNode>,
+    /// Poem-wide syllable index (matches `ParseResult.syllables` order).
+    pub global_index: SyllableGlobalIndex,
+}
+
+impl SyllableLayer for SyllableNode {
+    fn syllable_text(&self) -> &str {
+        self.inner.text.as_str()
+    }
+
+    fn syllable_type(&self) -> SyllableType {
+        self.inner.syllable_type
+    }
+
+    fn letters(&self) -> &[LetterNode] {
+        &self.letters
+    }
+
+    fn global_syllable_index(&self) -> SyllableGlobalIndex {
+        self.global_index
+    }
+}
+
+/// Syllables belonging to one **linguistic** word (whitespace-separated token).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LinguisticWordNode {
+    pub word_index_in_line: usize,
+    pub syllables: Vec<SyllableNode>,
+}
+
+/// Word (foot / seer): syllables grouped by foot rule.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WordNode {
+    pub foot_type: String,
+    pub syllables: Vec<SyllableNode>,
+    /// Index among feet on this physical line (0-based).
+    pub word_index_in_line: usize,
+    /// Poem-wide foot index (matches `ParseResult.feet` order).
+    pub foot_index_global: usize,
+}
+
+impl WordLayer for WordNode {
+    fn syllables(&self) -> &[SyllableNode] {
+        &self.syllables
+    }
+
+    fn foot_type(&self) -> &str {
+        self.foot_type.as_str()
+    }
+
+    fn word_index_in_line(&self) -> usize {
+        self.word_index_in_line
+    }
+
+    fn foot_index_global(&self) -> usize {
+        self.foot_index_global
+    }
+}
+
+/// One physical line of the normalized poem.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PoemLineNode {
+    pub line_index: usize,
+    pub line_class: String,
+    /// Linguistic words on this line (Ner/Nirai per word; does not merge across spaces).
+    pub linguistic_words: Vec<LinguisticWordNode>,
+    pub words: Vec<WordNode>,
+}
+
+impl LineLayer for PoemLineNode {
+    fn line_index(&self) -> usize {
+        self.line_index
+    }
+
+    fn words(&self) -> &[WordNode] {
+        &self.words
+    }
+
+    fn line_class(&self) -> &str {
+        self.line_class.as_str()
+    }
+}
+
+/// Root aggregate: input text, tree lines, flat syllables (parallel legacy surface), linkages.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PoemNode {
+    pub normalized_text: String,
+    pub lines: Vec<PoemLineNode>,
+    pub syllables_flat: Vec<Syllable>,
+    pub linkage: Vec<Linkage>,
+}
+
+impl PoemLayer for PoemNode {
+    fn lines(&self) -> &[PoemLineNode] {
+        &self.lines
+    }
+
+    fn syllables_linear(&self) -> &[Syllable] {
+        &self.syllables_flat
+    }
+
+    fn linkage(&self) -> &[Linkage] {
+        &self.linkage
+    }
+
+    fn normalized_source(&self) -> &str {
+        self.normalized_text.as_str()
+    }
+}
+
+// --- Trait contracts (what upper layers need from lower layers) ---
+
+pub trait LetterLayer {}
+
+pub trait SyllableLayer {
+    fn syllable_text(&self) -> &str;
+    fn syllable_type(&self) -> SyllableType;
+    fn letters(&self) -> &[LetterNode];
+    fn global_syllable_index(&self) -> SyllableGlobalIndex;
+}
+
+pub trait WordLayer {
+    fn syllables(&self) -> &[SyllableNode];
+    fn foot_type(&self) -> &str;
+    fn word_index_in_line(&self) -> usize;
+    fn foot_index_global(&self) -> usize;
+}
+
+pub trait LineLayer {
+    fn line_index(&self) -> usize;
+    fn words(&self) -> &[WordNode];
+    fn line_class(&self) -> &str;
+}
+
+pub trait PoemLayer {
+    fn lines(&self) -> &[PoemLineNode];
+    fn syllables_linear(&self) -> &[Syllable];
+    fn linkage(&self) -> &[Linkage];
+    fn normalized_source(&self) -> &str;
+}
+
+fn linguistic_words_per_line(syllables: &[Syllable]) -> Vec<Vec<LinguisticWordNode>> {
+    if syllables.is_empty() {
+        return vec![];
+    }
+    let max_li = syllables.iter().map(|s| s.line_index).max().unwrap_or(0);
+    let mut per_line: Vec<std::collections::BTreeMap<usize, Vec<(usize, Syllable)>>> =
+        vec![std::collections::BTreeMap::new(); max_li.saturating_add(1)];
+    for (gi, s) in syllables.iter().enumerate() {
+        let li = s.line_index;
+        if li >= per_line.len() {
+            per_line.resize(li + 1, std::collections::BTreeMap::new());
+        }
+        per_line[li]
+            .entry(s.word_index_in_line)
+            .or_default()
+            .push((gi, s.clone()));
+    }
+    let mut out: Vec<Vec<LinguisticWordNode>> = Vec::with_capacity(per_line.len());
+    for line_map in per_line {
+        let mut words: Vec<LinguisticWordNode> = Vec::new();
+        for (wi, pairs) in line_map {
+            let syllables: Vec<SyllableNode> = pairs
+                .into_iter()
+                .map(|(global_index, syl)| SyllableNode {
+                    inner: syl.clone(),
+                    letters: letters_from_syllable_text(&syl.text)
+                        .into_iter()
+                        .map(|inner| LetterNode { inner })
+                        .collect(),
+                    global_index,
+                })
+                .collect();
+            words.push(LinguisticWordNode {
+                word_index_in_line: wi,
+                syllables,
+            });
+        }
+        out.push(words);
+    }
+    out
+}
+
+/// Build the hierarchical tree from poem-wide syllables, foot placements, positions, and linkage.
+pub fn build_poem_tree(
+    normalized_text: String,
+    syllables: &[Syllable],
+    foot_positions: &[crate::linkage::FootPosition],
+    placements: &[crate::foot::FootPlacement],
+    linkage: Vec<Linkage>,
+) -> PoemNode {
+    let syllables_flat: Vec<Syllable> = syllables.to_vec();
+    let linguistic_by_line = linguistic_words_per_line(&syllables_flat);
+
+    let mut lines_map: std::collections::BTreeMap<usize, Vec<WordNode>> =
+        std::collections::BTreeMap::new();
+
+    for (placement, pos) in placements.iter().zip(foot_positions.iter()) {
+        let foot_index_global = pos.foot_index;
+        let line_index = pos.line_index;
+        let word_index_in_line = pos.word_index_in_line;
+
+        let mut word_syllables: Vec<SyllableNode> = Vec::new();
+        for (local_i, syl) in placement.foot.syllables.iter().enumerate() {
+            let global_index = placement.syllable_range.start + local_i;
+            let letters: Vec<LetterNode> = letters_from_syllable_text(&syl.text)
+                .into_iter()
+                .map(|inner| LetterNode { inner })
+                .collect();
+            word_syllables.push(SyllableNode {
+                inner: syl.clone(),
+                letters,
+                global_index,
+            });
+        }
+
+        let word = WordNode {
+            foot_type: placement.foot.foot_type.clone(),
+            syllables: word_syllables,
+            word_index_in_line,
+            foot_index_global,
+        };
+
+        lines_map.entry(line_index).or_default().push(word);
+    }
+
+    let max_line = lines_map
+        .keys()
+        .next_back()
+        .copied()
+        .unwrap_or(0)
+        .max(linguistic_by_line.len().saturating_sub(1));
+    let mut lines: Vec<PoemLineNode> = Vec::with_capacity(max_line + 1);
+    for li in 0..=max_line {
+        let words = lines_map.remove(&li).unwrap_or_default();
+        let linguistic_words = linguistic_by_line
+            .get(li)
+            .cloned()
+            .unwrap_or_default();
+        lines.push(PoemLineNode {
+            line_index: li,
+            line_class: "—".to_string(),
+            linguistic_words,
+            words,
+        });
+    }
+
+    PoemNode {
+        normalized_text,
+        lines,
+        syllables_flat,
+        linkage,
+    }
+}

--- a/tamil-seiyul-alagi/src/presentation.rs
+++ b/tamil-seiyul-alagi/src/presentation.rs
@@ -6,6 +6,9 @@
 //! - Generating educational explanations
 //!
 //! IMPORTANT: This layer should NEVER be used inside the core calculation logic.
+//!
+//! Logic layer uses readable foot **patterns** like `Ner-Ner`, `Nirai-Nirai-Nirai`.
+//! Here we map those to Tamil mnemonics (தேமா, …) plus simple Latin (thema, …).
 
 use crate::{Foot, Linkage, MetreType, ParseResult, Syllable};
 
@@ -25,12 +28,15 @@ pub struct DisplaySyllable {
 
 pub struct DisplayFoot {
     pub text: String,
-    pub foot_type: String, // "தேமா", "புளிமா", etc.
+    /// Tamil mnemonic · simple Latin when known; otherwise raw `Ner-Nirai` pattern from logic.
+    pub foot_type: String,
 }
 
 pub struct DisplayTalai {
     pub from: usize,
     pub to: usize,
+    pub from_line: usize,
+    pub to_line: usize,
     pub talai_type: String, // "வெண்டளை", "ஆசிரியத்தளை"
     pub is_valid: bool,
 }
@@ -74,7 +80,49 @@ fn to_display_foot(f: &Foot) -> DisplayFoot {
             .iter()
             .map(|s| s.text.as_str())
             .collect::<String>(),
-        foot_type: f.foot_type.clone(), // Already contains traditional name
+        foot_type: foot_pattern_display(&f.foot_type),
+    }
+}
+
+/// Tamil + simple Latin for classical feet; unknown patterns pass through as-is.
+pub fn foot_pattern_display(pattern: &str) -> String {
+    match pattern {
+        // 1 acai
+        "Ner" => "மா (ma)".to_string(),
+        "Nirai" => "விளம் (vilam)".to_string(),
+        // 2 acai
+        "Ner-Ner" => "தேமா (thema)".to_string(),
+        "Ner-Nirai" => "கூவிளம் (ku vilam)".to_string(),
+        "Nirai-Ner" => "புளிமா (pulima)".to_string(),
+        "Nirai-Nirai" => "கருவிளம் (karuvilam)".to_string(),
+        // 3 acai — kayak / kavi (order MSB = first syllable)
+        "Ner-Ner-Ner" => "தேமாங்காய் (thema kangay)".to_string(),
+        "Ner-Ner-Nirai" => "தேமாகவி (thema kavi)".to_string(),
+        "Ner-Nirai-Ner" => "கூவிளங்காய் (ku vilam kangay)".to_string(),
+        "Ner-Nirai-Nirai" => "கூவிளகவி (ku vilam kavi)".to_string(),
+        "Nirai-Ner-Ner" => "புளிமாங்காய் (pulima kangay)".to_string(),
+        "Nirai-Ner-Nirai" => "புளிமாகவி (pulima kavi)".to_string(),
+        "Nirai-Nirai-Ner" => "கருவிளங்காய் (karuvilam kangay)".to_string(),
+        "Nirai-Nirai-Nirai" => "கருவிளகவி (karuvilam kavi)".to_string(),
+        // 4 acai — classical catalogue (same bit order as logic / prototype)
+        "Ner-Ner-Ner-Ner" => "தேமாந்தப்பூ (thema thanthapuu)".to_string(),
+        "Ner-Ner-Ner-Nirai" => "தேமாந்தநிழல் (thema thanth nizhal)".to_string(),
+        "Ner-Ner-Nirai-Ner" => "தேமாரும்பூ (thema arumpuu)".to_string(),
+        "Ner-Ner-Nirai-Nirai" => "தேமாருநிழல் (thema aru nizhal)".to_string(),
+        "Ner-Nirai-Ner-Ner" => "கூவிளந்தப்பூ (ku vilam thanthapuu)".to_string(),
+        "Ner-Nirai-Ner-Nirai" => "கூவிளந்தநிழல் (ku vilam thanth nizhal)".to_string(),
+        "Ner-Nirai-Nirai-Ner" => "கூவிளரும்பூ (ku vilam arumpuu)".to_string(),
+        "Ner-Nirai-Nirai-Nirai" => "கூவிளருநிழல் (ku vilam aru nizhal)".to_string(),
+        "Nirai-Ner-Ner-Ner" => "புளிமாந்தப்பூ (pulima thanthapuu)".to_string(),
+        "Nirai-Ner-Ner-Nirai" => "புளிமாந்தநிழல் (pulima thanth nizhal)".to_string(),
+        "Nirai-Ner-Nirai-Ner" => "புளிமாரும்பூ (pulima arumpuu)".to_string(),
+        "Nirai-Ner-Nirai-Nirai" => "புளிமாருநிழல் (pulima aru nizhal)".to_string(),
+        "Nirai-Nirai-Ner-Ner" => "கருவிளந்தப்பூ (karuvilam thanthapuu)".to_string(),
+        "Nirai-Nirai-Ner-Nirai" => "கருவிளந்தநிழல் (karuvilam thanth nizhal)".to_string(),
+        "Nirai-Nirai-Nirai-Ner" => "கருவிளரும்பூ (karuvilam arumpuu)".to_string(),
+        "Nirai-Nirai-Nirai-Nirai" => "கருவிளருநிழல் (karuvilam aru nizhal)".to_string(),
+        "" => "—".to_string(),
+        other => other.to_string(),
     }
 }
 
@@ -82,6 +130,8 @@ fn to_display_talai(t: &Linkage) -> DisplayTalai {
     DisplayTalai {
         from: t.from_foot,
         to: t.to_foot,
+        from_line: t.from.line_index,
+        to_line: t.to.line_index,
         talai_type: match t.linkage_type {
             crate::linkage::LinkageType::VenTalai => "வெண்டளை".to_string(),
             crate::linkage::LinkageType::AsiriyaTalai => "ஆசிரியத்தளை".to_string(),

--- a/tamil-seiyul-alagi/src/syllable.rs
+++ b/tamil-seiyul-alagi/src/syllable.rs
@@ -2,7 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 pub enum SyllableType {
     Ner,
     Nirai,
@@ -15,6 +15,12 @@ pub struct Syllable {
     pub split_hint: Option<String>,
     pub alt_split: bool,
     pub rule_ref: Option<String>,
+    /// Physical line in normalized poem (0-based); linguistic word boundary used during segmentation.
+    #[serde(default)]
+    pub line_index: usize,
+    /// Index of the linguistic word within `line_index` (whitespace-separated).
+    #[serde(default)]
+    pub word_index_in_line: usize,
 }
 
 #[cfg(test)]
@@ -29,6 +35,8 @@ mod tests {
             split_hint: Some("hint".to_string()),
             alt_split: true,
             rule_ref: Some("SYL-TEST-01".to_string()),
+            line_index: 0,
+            word_index_in_line: 0,
         };
 
         assert_eq!(s.text, "கா");

--- a/tamil-seiyul-alagi/src/syllable_builder.rs
+++ b/tamil-seiyul-alagi/src/syllable_builder.rs
@@ -27,7 +27,28 @@ impl SyllableBuilder {
         }
     }
 
-    pub fn build(mut self, units: &[ProsodicUnit]) -> Vec<Syllable> {
+    /// Segment **one linguistic word** (contiguous non-whitespace graphemes → prosodic units).
+    /// Must not be called with units spanning multiple whitespace-separated words — boundaries are lost when spaces are dropped upstream.
+    pub fn build_word_segment(
+        self,
+        units: &[ProsodicUnit],
+        line_index: usize,
+        word_index_in_line: usize,
+    ) -> Vec<Syllable> {
+        self.build_inner(units, line_index, word_index_in_line)
+    }
+
+    /// Whole-stream segmentation (crosses linguistic word boundaries if `units` spans multiple words).
+    pub fn build(self, units: &[ProsodicUnit]) -> Vec<Syllable> {
+        self.build_inner(units, 0, 0)
+    }
+
+    fn build_inner(
+        mut self,
+        units: &[ProsodicUnit],
+        line_index: usize,
+        word_index_in_line: usize,
+    ) -> Vec<Syllable> {
         if units.is_empty() {
             return self.result;
         }
@@ -63,7 +84,9 @@ impl SyllableBuilder {
                     len,
                     SyllableType::Nirai,
                     "Nirai (triplet)",
-                    is_last_syllable
+                    is_last_syllable,
+                    line_index,
+                    word_index_in_line,
                 );
 
                 pos += len;
@@ -93,7 +116,9 @@ impl SyllableBuilder {
                     len,
                     syllable_type,
                     "Nirai/Ner (pair)",
-                    is_last_syllable
+                    is_last_syllable,
+                    line_index,
+                    word_index_in_line,
                 );
                 pos += len;
                 continue;
@@ -116,7 +141,9 @@ impl SyllableBuilder {
                     len,
                     syllable_type,
                     "Nirai/Ner (pair)",
-                    is_last_syllable
+                    is_last_syllable,
+                    line_index,
+                    word_index_in_line,
                 );
                 pos += 1;
             } else {
@@ -134,7 +161,9 @@ impl SyllableBuilder {
         len: usize,
         syllable_type: SyllableType,
         rule: &str,
-        is_last_syllable: bool
+        is_last_syllable: bool,
+        line_index: usize,
+        word_index_in_line: usize,
     ) {
         let text: String = units[start..start + len].iter().map(|u| u.text()).collect();
 
@@ -148,12 +177,17 @@ impl SyllableBuilder {
             syllable_type,
             split_hint: hint,
             alt_split: self.alt_scansion,
-            rule_ref: Some(rule.to_string())
+            rule_ref: Some(rule.to_string()),
+            line_index,
+            word_index_in_line,
         });
     }
 
-    //  In the whole word, last characters decide the condition
+    // In the whole word, last characters decide the condition
     fn is_uyir_u(&self, units: &[ProsodicUnit]) -> bool {
+        if units.len() < 2 {
+            return false;
+        }
         let last_index = units.len() - 1;
         let last_char = &units[last_index];
 

--- a/tamil-seiyul-alagi/src/types.rs
+++ b/tamil-seiyul-alagi/src/types.rs
@@ -1,5 +1,7 @@
-use crate::{Foot, Linkage, MetreType, Syllable, Talai};
 use serde::{Deserialize, Serialize};
+
+use crate::poem_tree::PoemNode;
+use crate::{Foot, Linkage, MetreType, Syllable, Talai};
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ParseOptions {
@@ -15,11 +17,14 @@ pub struct ParseResult {
     pub normalized_text: String,
     pub letter_count: usize,
     pub vikalpa_count: usize,
+    /// Root hierarchical container: Poem → Line → Word → Syllable → Letter.
+    pub poem: PoemNode,
     pub syllables: Vec<Syllable>,
     pub feet: Vec<Foot>,
     pub linkage: Vec<Linkage>,
     #[serde(default)]
     pub talai: Vec<Talai>,
+    /// Flattened lines for adapters expecting `feet` per line (mirrors `poem.lines`).
     pub lines: Vec<Line>,
     pub metre_type: Option<MetreType>,
     #[serde(default)]
@@ -50,4 +55,22 @@ pub struct MetreHypothesis {
     pub aggregate_score: i32,
     pub violations: Vec<RuleId>,
     pub rule_ids: Vec<RuleId>,
+}
+
+/// Legacy `Line` rows (`feet` per physical line) derived from the hierarchical `PoemNode`.
+pub fn flat_lines_from_poem(poem: &PoemNode) -> Vec<Line> {
+    poem.lines
+        .iter()
+        .map(|ln| Line {
+            line_class: ln.line_class.clone(),
+            feet: ln
+                .words
+                .iter()
+                .map(|w| Foot {
+                    syllables: w.syllables.iter().map(|s| s.inner.clone()).collect(),
+                    foot_type: w.foot_type.clone(),
+                })
+                .collect(),
+        })
+        .collect()
 }

--- a/tamil-seiyul-alagi/src/word_scope.rs
+++ b/tamil-seiyul-alagi/src/word_scope.rs
@@ -1,0 +1,88 @@
+//! Linguistic word boundaries from normalized text (whitespace-separated tokens per line).
+
+use crate::letter;
+use crate::syllable::Syllable;
+use crate::syllable_builder::SyllableBuilder;
+use unicode_segmentation::UnicodeSegmentation;
+
+/// Syllables in poem order: each **linguistic word** (whitespace-separated run) is segmented separately
+/// so Ner/Nirai boundaries never cross words (spaces are dropped in `to_prosodic_units`).
+pub fn segment_syllables_from_normalized(normalized: &str, alt_scansion: bool) -> Vec<Syllable> {
+    let by_line = linguistic_words_graphemes_by_line(normalized);
+    let mut out = Vec::new();
+    for (line_index, line_words) in by_line.iter().enumerate() {
+        for (word_index_in_line, word_graphemes) in line_words.iter().enumerate() {
+            let grapheme_refs: Vec<&str> = word_graphemes.iter().copied().collect();
+            let units = letter::to_prosodic_units(&grapheme_refs);
+            let mut seg = SyllableBuilder::new(alt_scansion).build_word_segment(
+                &units,
+                line_index,
+                word_index_in_line,
+            );
+            out.append(&mut seg);
+        }
+    }
+    out
+}
+
+/// For each physical line, a list of words; each word is the slice of grapheme clusters (non-whitespace runs).
+pub fn linguistic_words_graphemes_by_line<'a>(normalized: &'a str) -> Vec<Vec<Vec<&'a str>>> {
+    normalized
+        .lines()
+        .map(|line| {
+            let graphemes: Vec<&str> = line.graphemes(true).collect();
+            let mut words: Vec<Vec<&str>> = Vec::new();
+            let mut i = 0usize;
+            while i < graphemes.len() {
+                while i < graphemes.len() && is_word_sep_grapheme(graphemes[i]) {
+                    i += 1;
+                }
+                if i >= graphemes.len() {
+                    break;
+                }
+                let start = i;
+                while i < graphemes.len() && !is_word_sep_grapheme(graphemes[i]) {
+                    i += 1;
+                }
+                words.push(graphemes[start..i].to_vec());
+            }
+            words
+        })
+        .collect()
+}
+
+fn is_word_sep_grapheme(g: &str) -> bool {
+    g.chars().all(|c| c.is_whitespace())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn two_linguistic_words_split_on_space() {
+        let normalized = "அஃ கு ";
+        let by_line = linguistic_words_graphemes_by_line(normalized);
+        assert_eq!(by_line.len(), 1);
+        assert_eq!(by_line[0].len(), 2);
+        assert_eq!(
+            by_line[0][0].iter().copied().collect::<String>(),
+            "அஃ"
+        );
+        assert_eq!(
+            by_line[0][1].iter().copied().collect::<String>(),
+            "கு"
+        );
+    }
+
+    #[test]
+    fn segment_does_not_merge_across_space_two_words_two_syllables() {
+        let normalized = "அஃ கு ";
+        let syl = segment_syllables_from_normalized(normalized, false);
+        assert_eq!(syl.len(), 2, "must not merge அஃ and கு into one Nirai across space");
+        assert_eq!(syl[0].word_index_in_line, 0);
+        assert_eq!(syl[1].word_index_in_line, 1);
+        assert_eq!(syl[0].line_index, 0);
+        assert_eq!(syl[1].line_index, 0);
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## ✨ Big refactor — hierarchical prosody + honest syllable/word UI

We’ve landed a solid slice of the architecture from issue #40: **tree-shaped poem model**, **talai with real positions**, **Ner/Nirai–first feet**, and **live preview that trusts the parser** instead of guessing.

---

### 🔗 Linkage (talai)
- **`FootPosition`** on each bond end: global foot index, **line index**, **word index in line**.
- Bonds are **consecutive feet poem-wide** (including **across line breaks**).

### 🌳 Poem → Line → Word → Syllable → Letter
- **`PoemNode`** + traits (`PoemLayer`, `LineLayer`, …).
- **`ParseResult.poem`** holds the tree; flat **`syllables` / `feet` / `linkage`** kept for adapters.
- **`linguistic_words`** per line: syllables grouped by **whitespace-separated token**.
- **Letters** under each syllable via grapheme prosodic units.

### 📝 Syllables & feet (logic)
- **Segmentation runs per linguistic word** (spaces aren’t dropped into one blob).
- **`Foot.foot_type`** = readable **`Ner-Nirai-Nirai`** style patterns — not `tEmA`-style transliteration in core JSON.
- **Presentation** maps patterns → Tamil + simple Latin (**தேமா (thema)**, …).

### 🖥️ Frontend (live syllables)
- **`feetPerPhysicalLine`**: uses WASM **`lines[].feet`** when editor line count **matches** parser lines — no more random split across lines for that case.
- **`groupsFromFeet`**: one chip group **per foot** (= per word) — **no** `alignSyllablesToWords` length heuristic for the happy path.

---

### 📊 CRAP-style baseline

Updated **`tamil-seiyul-alagi/QUALITY_CRAP_BASELINE.md`** (2026-04-29): refreshed hotspot table (`parse_poem`, `word_scope`, `poem_tree`, linkage positions, linguistic-word feet). **Sum of hotspot scores = 33** (manual rows per file formula). Changelog notes superseded chunk-feet / flat-stream rows.

---

### 🧪 Tests
- **`cargo test`** (Rust) ✅  
- Vitest for **`parserFeetLayout`** helpers ✅  

---

### 📦 Follow-up
Rebuild WASM when integrating: **`pnpm run build:wasm`**.

---

🙏 **Thanks for steering from mobile** — this refactor sets us up for ornaments (thodai), metre rules, and batch parsing without fighting the data model.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc37b7c2-4c7e-493d-ab67-07651df734af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc37b7c2-4c7e-493d-ab67-07651df734af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

