### PR TITLE
fix(live-preview): stable parse cache + safe feet on line mismatch

### DIFF
--- a/src/lib/__tests__/adaptWasmParseJson.test.ts
+++ b/src/lib/__tests__/adaptWasmParseJson.test.ts
@@ -33,6 +33,49 @@ describe('adaptWasmJsonToParsedPoem', () => {
     expect(out!.lines[0]!.feet[0]!.syllables[0]!.syllable_type).toBe('Ner')
   })
 
+  it('prefers linguistic_words over words when both present (misplaced tree feet)', () => {
+    const wasm = {
+      original_text: 'a\nb',
+      syllables: [],
+      feet: [],
+      lines: [],
+      poem: {
+        lines: [
+          {
+            line_class: '—',
+            line_index: 0,
+            words: [
+              {
+                foot_type: 'Ner-Ner',
+                foot_index_global: 0,
+                word_index_in_line: 0,
+                syllables: [
+                  { inner: { text: 'whole', syllable_type: 'Ner', alt_split: false } },
+                  { inner: { text: 'poem', syllable_type: 'Ner', alt_split: false } },
+                ],
+              },
+            ],
+            linguistic_words: [
+              {
+                word_index_in_line: 0,
+                syllables: [{ inner: { text: 'only', syllable_type: 'Ner', alt_split: false } }],
+              },
+            ],
+          },
+        ],
+      },
+      metre_type: null,
+      letter_count: 0,
+      vikalpa_count: 0,
+      errors: [],
+    }
+
+    const out = adaptWasmJsonToParsedPoem(wasm)
+    expect(out).not.toBeNull()
+    expect(out!.lines[0]!.feet).toHaveLength(1)
+    expect(out!.lines[0]!.feet[0]!.syllables[0]!.text).toBe('only')
+  })
+
   it('extracts per-line feet from nested poem.words when top-level lines is empty', () => {
     const wasm = {
       original_text: 'a\nb',

--- a/src/lib/__tests__/adaptWasmParseJson.test.ts
+++ b/src/lib/__tests__/adaptWasmParseJson.test.ts
@@ -33,6 +33,102 @@ describe('adaptWasmJsonToParsedPoem', () => {
     expect(out!.lines[0]!.feet[0]!.syllables[0]!.syllable_type).toBe('Ner')
   })
 
+  it('extracts per-line feet from nested poem.words when top-level lines is empty', () => {
+    const wasm = {
+      original_text: 'a\nb',
+      syllables: [],
+      feet: [],
+      lines: [],
+      poem: {
+        lines: [
+          {
+            line_class: '—',
+            line_index: 0,
+            words: [
+              {
+                foot_type: 'Ner',
+                foot_index_global: 0,
+                word_index_in_line: 0,
+                syllables: [{ inner: { text: 'x', syllable_type: 'Ner', alt_split: false } }],
+              },
+            ],
+          },
+          {
+            line_class: '—',
+            line_index: 1,
+            words: [
+              {
+                foot_type: 'Nirai',
+                foot_index_global: 1,
+                word_index_in_line: 0,
+                syllables: [{ inner: { text: 'y', syllable_type: 'Nirai', alt_split: false } }],
+              },
+            ],
+          },
+        ],
+      },
+      metre_type: null,
+      letter_count: 0,
+      vikalpa_count: 0,
+      errors: [],
+    }
+
+    const out = adaptWasmJsonToParsedPoem(wasm)
+    expect(out).not.toBeNull()
+    expect(out!.lines).toHaveLength(2)
+    expect(out!.lines[0]!.feet[0]!.syllables[0]!.text).toBe('x')
+    expect(out!.lines[1]!.feet[0]!.syllables[0]!.text).toBe('y')
+  })
+
+  it('uses linguistic_words when words is empty (mirrors WASM lines 2+)', () => {
+    const wasm = {
+      original_text: 'a\nb',
+      syllables: [],
+      feet: [],
+      lines: [],
+      poem: {
+        lines: [
+          {
+            line_class: '—',
+            line_index: 0,
+            words: [
+              {
+                foot_type: 'Ner',
+                foot_index_global: 0,
+                word_index_in_line: 0,
+                syllables: [{ inner: { text: 'x', syllable_type: 'Ner', alt_split: false } }],
+              },
+            ],
+          },
+          {
+            line_class: '—',
+            line_index: 1,
+            words: [],
+            linguistic_words: [
+              {
+                word_index_in_line: 0,
+                syllables: [
+                  { inner: { text: 'அ', syllable_type: 'Ner', alt_split: false } },
+                  { inner: { text: 'ஆ', syllable_type: 'Nirai', alt_split: false } },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      metre_type: null,
+      letter_count: 0,
+      vikalpa_count: 0,
+      errors: [],
+    }
+
+    const out = adaptWasmJsonToParsedPoem(wasm)
+    expect(out).not.toBeNull()
+    expect(out!.lines).toHaveLength(2)
+    expect(out!.lines[1]!.feet[0]!.foot_type).toBe('Ner-Nirai')
+    expect(out!.lines[1]!.feet[0]!.syllables).toHaveLength(2)
+  })
+
   it('accepts null metre_type from Rust Option::None', () => {
     const wasm = {
       original_text: 'ab',

--- a/src/lib/__tests__/livePreviewController.test.ts
+++ b/src/lib/__tests__/livePreviewController.test.ts
@@ -1,0 +1,65 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { LivePreviewController } from '#/lib/livePreviewController'
+import { normalizePoemText } from '#/lib/poemTextNormalize'
+import type { LivePreviewState } from '#/types/livePreview'
+
+vi.mock('#/lib/wasmParse', () => ({
+  runWasmParse: vi.fn(async (text: string) => {
+    const norm = text.replace(/\r\n/g, '\n')
+    return JSON.stringify({
+      original_text: norm,
+      normalized_text: norm,
+      letter_count: 0,
+      vikalpa_count: 0,
+      syllables: [{ text: 'a', syllable_type: 'Ner' }],
+      feet: [{ foot_type: 'Ner', syllables: [{ text: 'a', syllable_type: 'Ner' }] }],
+      lines: [
+        { line_class: '—', feet: [{ foot_type: 'Ner', syllables: [{ text: 'a', syllable_type: 'Ner' }] }] },
+      ],
+      poem: { lines: [], syllables_flat: [], normalized_text: norm, linkage: [] },
+      linkage: [],
+      talai: [],
+      metre_type: null,
+      errors: [],
+    })
+  }),
+}))
+
+describe('LivePreviewController', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('uses normalizePoemText for cache; trailing newline vs none are different parses', async () => {
+    const states: LivePreviewState[] = []
+    const c = new LivePreviewController(0, (s) => {
+      states.push(structuredClone(s))
+    })
+
+    c.setSource('அ\n')
+    await vi.runAllTimersAsync()
+
+    const readyAfterFirst = states.filter((s) => s.status === 'ready' && s.parsed != null)
+    expect(readyAfterFirst.length).toBeGreaterThan(0)
+    const normFirst = normalizePoemText(readyAfterFirst[readyAfterFirst.length - 1]!.parsed!.original_text)
+
+    c.setSource('அ')
+    await vi.runAllTimersAsync()
+
+    const readyAfterSecond = states.filter((s) => s.status === 'ready' && s.parsed != null)
+    const last = readyAfterSecond[readyAfterSecond.length - 1]!
+    const normSecond = normalizePoemText(last.parsed!.original_text)
+    expect(normFirst).not.toBe(normSecond)
+
+    c.dispose()
+  })
+})

--- a/src/lib/__tests__/livePreviewEditScenarios.test.ts
+++ b/src/lib/__tests__/livePreviewEditScenarios.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Live preview / layout contracts under aggressive poem edits.
+ *
+ * **Goals**
+ * - Document expected behaviour: editor physical lines ↔ WASM `parsed.lines` ↔ `feetPerPhysicalLine`.
+ * - Integration tests run **only** when a WASM bundle exists (`pnpm run build:wasm` → `public/wasm/` or `src/wasm/`).
+ *
+ * **Failures here are learning signals** — fix implementation until these pass in CI (after WASM build step).
+ */
+
+import { describe, expect, it, beforeAll } from 'vitest'
+
+import { feetPerPhysicalLine, groupsFromFeet } from '#/lib/parserFeetLayout'
+import { normalizePoemText } from '#/lib/poemTextNormalize'
+import { physicalPoemLines } from '#/lib/mapFeetToPhysicalLines'
+import type { ParsedPoem } from '#/types/parsedPoem'
+
+import {
+  createWasmParsePoem,
+  isWasmPkgBuilt,
+  type WasmParseFn,
+} from '#/lib/__tests__/wasmParseHarness'
+
+/** Same poem shape as mobile repro — multi-line Tamil with spaces & newline endings */
+export const SAMPLE_POEM_THREE_LINES = `சுடர்த்தொடீஇ கேளாய் தெருவில்நாம்
+மணற்சிற்றில் காலில் சிதையா அடை
+கோதை பரிந்து வரிப்பந்து கொண்டோ
+`
+
+function totalFeet(buckets: ReturnType<typeof feetPerPhysicalLine>): number {
+  return buckets.reduce((n, row) => n + row.length, 0)
+}
+
+function totalSyllablesFromBuckets(buckets: ReturnType<typeof feetPerPhysicalLine>): number {
+  return buckets.reduce(
+    (n, row) => n + row.reduce((m, ft) => m + ft.syllables.length, 0),
+    0,
+  )
+}
+
+describe('live preview layout (no WASM)', () => {
+  it('physicalPoemLines count matches structured.lines → feet buckets get syllables', () => {
+    const poemText = 'ஒன்று இரண்டு\nமூன்று நான்கு\n'
+    const parsed: ParsedPoem = {
+      original_text: poemText,
+      metre_type: '—',
+      letter_count: 0,
+      vikalpa_count: 0,
+      syllables: [],
+      lines: [
+        {
+          line_class: '—',
+          feet: [
+            {
+              foot_type: 'Ner-Ner',
+              syllables: [{ text: 'ஒன்று', syllable_type: 'Ner' }],
+            },
+            {
+              foot_type: 'Nirai',
+              syllables: [{ text: 'இரண்டு', syllable_type: 'Nirai' }],
+            },
+          ],
+        },
+        {
+          line_class: '—',
+          feet: [
+            {
+              foot_type: 'Ner',
+              syllables: [{ text: 'மூன்று', syllable_type: 'Ner' }],
+            },
+            {
+              foot_type: 'Ner',
+              syllables: [{ text: 'நான்கு', syllable_type: 'Ner' }],
+            },
+          ],
+        },
+      ],
+    }
+
+    expect(physicalPoemLines(poemText).length).toBe(parsed.lines.length)
+
+    const buckets = feetPerPhysicalLine(parsed, poemText)
+    expect(buckets.length).toBe(2)
+    expect(totalFeet(buckets)).toBeGreaterThan(0)
+    expect(totalSyllablesFromBuckets(buckets)).toBeGreaterThan(0)
+
+    const row0 = groupsFromFeet(buckets[0] ?? [])
+    expect(row0.length).toBeGreaterThan(0)
+    expect(row0.every((g) => g.syllables.length > 0)).toBe(true)
+  })
+
+  it('when editor lines ≠ structured.lines, buckets are empty (no wrong-row bleed)', () => {
+    const poemText = 'a\nb\n'
+    const parsed: ParsedPoem = {
+      original_text: poemText,
+      metre_type: '—',
+      letter_count: 0,
+      vikalpa_count: 0,
+      syllables: [],
+      lines: [
+        {
+          line_class: '—',
+          feet: [{ foot_type: 'Ner', syllables: [{ text: 'x', syllable_type: 'Ner' }] }],
+        },
+      ],
+    }
+    expect(physicalPoemLines(poemText).length).toBe(2)
+    expect(parsed.lines.length).toBe(1)
+
+    const buckets = feetPerPhysicalLine(parsed, poemText)
+    expect(buckets.every((row) => row.length === 0)).toBe(true)
+  })
+
+  it('normalizePoemText distinguishes drafts that differ only by trailing newlines', () => {
+    expect(normalizePoemText('foo\n')).not.toBe(normalizePoemText('foo\n\n'))
+  })
+})
+
+describe.skipIf(!isWasmPkgBuilt())('live preview + WASM integration', () => {
+  let parsePoem: WasmParseFn
+
+  beforeAll(async () => {
+    parsePoem = await createWasmParsePoem()
+  })
+
+  it('parses sample poem and returns structured lines count matching physicalPoemLines', async () => {
+    const text = SAMPLE_POEM_THREE_LINES
+    const parsed = await parsePoem(text)
+    expect(parsed).not.toBeNull()
+    const p = parsed!
+
+    const phys = physicalPoemLines(text)
+    expect(p.lines.length).toBeGreaterThan(0)
+    expect(
+      phys.length,
+      'editor physical line count must equal WASM ParseResult.lines length for chip sync',
+    ).toBe(p.lines.length)
+
+    const buckets = feetPerPhysicalLine(p, text)
+    expect(totalFeet(buckets)).toBeGreaterThan(0)
+    expect(totalSyllablesFromBuckets(buckets)).toBeGreaterThan(0)
+
+    for (let i = 0; i < buckets.length; i++) {
+      const groups = groupsFromFeet(buckets[i] ?? [])
+      expect(
+        groups.length,
+        `line ${i} should show at least one word group when layout matches`,
+      ).toBeGreaterThan(0)
+    }
+  })
+
+  it('every step in an aggressive edit sequence stays layout-aligned or intentionally empties chips', async () => {
+    const steps: string[] = [
+      SAMPLE_POEM_THREE_LINES.trim(),
+      SAMPLE_POEM_THREE_LINES,
+      SAMPLE_POEM_THREE_LINES.split('\n').reverse().join('\n'),
+      SAMPLE_POEM_THREE_LINES.replace(/\n/g, '\n\n'),
+      SAMPLE_POEM_THREE_LINES + '\n\n',
+      `${SAMPLE_POEM_THREE_LINES}\r\n`,
+      SAMPLE_POEM_THREE_LINES.split('\n')[0] ?? '',
+      SAMPLE_POEM_THREE_LINES.replace('கோதை', ''),
+      'கற்றது மொழிந்தது\nஅறிந்தவர் சொல்லும் வழி',
+      'ஒரே வரியில் மட்டும் எல்லாம்',
+    ]
+
+    for (let step = 0; step < steps.length; step++) {
+      const text = steps[step]!
+      const parsed = await parsePoem(text)
+      if (!parsed) continue
+
+      const phys = physicalPoemLines(text)
+      const buckets = feetPerPhysicalLine(parsed, text)
+
+      expect(buckets.length).toBe(phys.length)
+
+      if (phys.length === parsed.lines.length) {
+        expect(
+          totalSyllablesFromBuckets(buckets),
+          `step ${step}: aligned layout should surface syllables`,
+        ).toBeGreaterThan(0)
+      } else {
+        expect(
+          buckets.every((r) => r.length === 0),
+          `step ${step}: mismatched counts should avoid placing feet on wrong rows`,
+        ).toBe(true)
+      }
+    }
+  })
+
+  it('adaptWasmJsonToParsedPoem round-trip matches parse_poem_wasm JSON shape', async () => {
+    const text = SAMPLE_POEM_THREE_LINES
+    const parsed = await parsePoem(text)
+    expect(parsed).not.toBeNull()
+    expect(parsed!.original_text).toBeTruthy()
+    expect(Array.isArray(parsed!.lines)).toBe(true)
+  })
+})
+
+describe('live preview controller cache key contract (documented behaviour)', () => {
+  it('same normalizePoemText(editor) === normalizePoemText(parsed.original_text) implies cache hit path', () => {
+    const editor = 'அஃ கு '
+    const parsedNorm = normalizePoemText(editor)
+    expect(parsedNorm).toBe(normalizePoemText(editor))
+  })
+})

--- a/src/lib/__tests__/livePreviewEditScenarios.test.ts
+++ b/src/lib/__tests__/livePreviewEditScenarios.test.ts
@@ -38,6 +38,26 @@ function totalSyllablesFromBuckets(buckets: ReturnType<typeof feetPerPhysicalLin
   )
 }
 
+function flattenFootSyllableTexts(lineFeet: ReturnType<typeof feetPerPhysicalLine>[number]): string[] {
+  return lineFeet.flatMap((ft) => ft.syllables.map((s) => s.text))
+}
+
+/**
+ * When legacy `lines` collapses the whole poem into `lines[0]`, the first row has chips and later rows are empty
+ * (mobile bug: "first line shows entire poem"). Multi-line + non-empty first row + empty rest + many syllables only on row0.
+ */
+function isFirstRowOnlyEntirePoemLayout(
+  buckets: ReturnType<typeof feetPerPhysicalLine>,
+  totalSyllablesInParse: number,
+): boolean {
+  if (buckets.length < 2) return false
+  const s0 = flattenFootSyllableTexts(buckets[0] ?? []).length
+  const sRest = buckets
+    .slice(1)
+    .reduce((n, row) => n + flattenFootSyllableTexts(row).length, 0)
+  return s0 > 0 && sRest === 0 && s0 === totalSyllablesInParse && totalSyllablesInParse > 4
+}
+
 describe('live preview layout (no WASM)', () => {
   it('physicalPoemLines count matches structured.lines → feet buckets get syllables', () => {
     const poemText = 'ஒன்று இரண்டு\nமூன்று நான்கு\n'
@@ -140,6 +160,14 @@ describe.skipIf(!isWasmPkgBuilt())('live preview + WASM integration', () => {
     expect(totalFeet(buckets)).toBeGreaterThan(0)
     expect(totalSyllablesFromBuckets(buckets)).toBeGreaterThan(0)
 
+    const s0 = flattenFootSyllableTexts(buckets[0] ?? []).length
+    expect(
+      s0 < p.syllables.length,
+      'first physical row must not show every syllable of the poem (regression: collapsed legacy lines)',
+    ).toBe(true)
+    expect(isFirstRowOnlyEntirePoemLayout(buckets, p.syllables.length)).toBe(false)
+    expect(totalSyllablesFromBuckets(buckets)).toBe(p.syllables.length)
+
     for (let i = 0; i < buckets.length; i++) {
       const groups = groupsFromFeet(buckets[i] ?? [])
       expect(
@@ -184,6 +212,39 @@ describe.skipIf(!isWasmPkgBuilt())('live preview + WASM integration', () => {
           `step ${step}: mismatched counts should avoid placing feet on wrong rows`,
         ).toBe(true)
       }
+    }
+  })
+
+  it('multi-line sample: total syllables partition across rows (not collapsed into row 0)', async () => {
+    const text = SAMPLE_POEM_THREE_LINES
+    const parsed = await parsePoem(text)
+    expect(parsed).not.toBeNull()
+    const buckets = feetPerPhysicalLine(parsed!, text)
+    const tot = totalSyllablesFromBuckets(buckets)
+    expect(tot).toBe(parsed!.syllables.length)
+    const maxSingleRow = Math.max(
+      ...buckets.map((row) => flattenFootSyllableTexts(row).length),
+      0,
+    )
+    expect(maxSingleRow).toBeLessThan(parsed!.syllables.length)
+  })
+
+  it('edit simulations: deleting lines / fragments never stacks entire poem on physical row 0 when counts align', async () => {
+    const variants = [
+      SAMPLE_POEM_THREE_LINES.split('\n').slice(0, 2).join('\n') + '\n',
+      SAMPLE_POEM_THREE_LINES.replace(/\n.+$/s, ''),
+      SAMPLE_POEM_THREE_LINES.trim(),
+      SAMPLE_POEM_THREE_LINES.replace(/கோதை\s*/, ''),
+    ]
+    for (let i = 0; i < variants.length; i++) {
+      const text = variants[i]!
+      const parsed = await parsePoem(text)
+      if (!parsed) continue
+      const phys = physicalPoemLines(text)
+      if (phys.length < 2 || phys.length !== parsed.lines.length) continue
+      const buckets = feetPerPhysicalLine(parsed, text)
+      expect(isFirstRowOnlyEntirePoemLayout(buckets, parsed.syllables.length)).toBe(false)
+      expect(totalSyllablesFromBuckets(buckets)).toBe(parsed.syllables.length)
     }
   })
 

--- a/src/lib/__tests__/mapFeetToPhysicalLines.test.ts
+++ b/src/lib/__tests__/mapFeetToPhysicalLines.test.ts
@@ -8,6 +8,13 @@ const mkFoot = (id: string): ParsedFoot => ({
   syllables: [{ text: id, syllable_type: 'Ner' }],
 })
 
+describe('physicalPoemLines', () => {
+  it('matches Rust str::lines length when poem ends with newline (no phantom 4th line)', () => {
+    expect(physicalPoemLines('a\nb\nc\n')).toEqual(['a', 'b', 'c'])
+    expect(physicalPoemLines('a\nb\nc')).toEqual(['a', 'b', 'c'])
+  })
+})
+
 describe('mapFeetToPhysicalLines', () => {
   it('returns one bucket for a single physical line', () => {
     const feet = [mkFoot('a'), mkFoot('b')]

--- a/src/lib/__tests__/parserFeetLayout.test.ts
+++ b/src/lib/__tests__/parserFeetLayout.test.ts
@@ -42,6 +42,20 @@ describe('feetPerPhysicalLine', () => {
     expect(buckets[0]![0]!.syllables[0]!.text).toBe('ab')
     expect(buckets[1]![0]!.syllables[0]!.text).toBe('cd')
   })
+
+  it('returns empty feet per line when parser line count mismatches (avoid wrong-row slices)', () => {
+    const p = poem([
+      {
+        line_class: '—',
+        feet: [{ foot_type: 'Ner', syllables: [{ text: 'only', syllable_type: 'Ner' }] }],
+      },
+    ])
+    const text = 'line one\nline two'
+    const buckets = feetPerPhysicalLine(p, text)
+    expect(buckets).toHaveLength(2)
+    expect(buckets[0]).toEqual([])
+    expect(buckets[1]).toEqual([])
+  })
 })
 
 describe('groupsFromFeet', () => {

--- a/src/lib/__tests__/poemTextNormalize.test.ts
+++ b/src/lib/__tests__/poemTextNormalize.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizePoemText } from '#/lib/poemTextNormalize'
+
+describe('normalizePoemText', () => {
+  it('does not trim trailing newlines — line structure differs', () => {
+    expect(normalizePoemText('a\n')).not.toBe(normalizePoemText('a\n\n'))
+  })
+
+  it('normalizes CRLF only', () => {
+    expect(normalizePoemText('x\r\ny')).toBe('x\ny')
+  })
+})

--- a/src/lib/__tests__/wasmParseHarness.ts
+++ b/src/lib/__tests__/wasmParseHarness.ts
@@ -1,0 +1,68 @@
+/**
+ * Load Rust WASM parser for Vitest integration tests.
+ *
+ * Resolution order (same artifacts as `pnpm run build:wasm`):
+ * 1. `public/wasm/` — copied for static serving (preferred)
+ * 2. `src/wasm/` — same copy for app imports
+ * 3. `tamil-seiyul-alagi/pkg/` — raw wasm-pack output
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+import { adaptWasmJsonToParsedPoem } from '#/lib/adaptWasmParseJson'
+import type { ParsedPoem } from '#/types/parsedPoem'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+/** Repo root: `src/lib/__tests__` → `../../../` */
+export const WORKSPACE_ROOT = path.resolve(__dirname, '../../..')
+
+const WASM_BUNDLE_DIRS = [
+  path.join(WORKSPACE_ROOT, 'public/wasm'),
+  path.join(WORKSPACE_ROOT, 'src/wasm'),
+  path.join(WORKSPACE_ROOT, 'tamil-seiyul-alagi/pkg'),
+] as const
+
+function resolveWasmBundle(): { js: string; wasm: string } | null {
+  for (const dir of WASM_BUNDLE_DIRS) {
+    const js = path.join(dir, 'thepulimaangani_parser.js')
+    const wasm = path.join(dir, 'thepulimaangani_parser_bg.wasm')
+    if (fs.existsSync(js) && fs.existsSync(wasm)) {
+      return { js, wasm }
+    }
+  }
+  return null
+}
+
+export function isWasmPkgBuilt(): boolean {
+  return resolveWasmBundle() != null
+}
+
+export type WasmParseFn = (poemText: string) => Promise<ParsedPoem | null>
+
+/** Throws if bundle missing — callers should guard with `isWasmPkgBuilt()`. */
+export async function createWasmParsePoem(): Promise<WasmParseFn> {
+  const bundle = resolveWasmBundle()
+  if (!bundle) {
+    throw new Error(
+      'WASM bundle not found. Run `pnpm run build:wasm` (outputs public/wasm/ and src/wasm/).',
+    )
+  }
+  const wasmBuf = fs.readFileSync(bundle.wasm)
+  const mod = await import(pathToFileURL(bundle.js).href)
+  await mod.default({ module_or_path: wasmBuf })
+
+  const parse_poem_wasm = mod.parse_poem_wasm as (text: string) => string
+
+  return async (poemText: string) => {
+    const raw = parse_poem_wasm(poemText)
+    if (typeof raw !== 'string' || raw.includes('Error:')) return null
+    try {
+      const json: unknown = JSON.parse(raw)
+      return adaptWasmJsonToParsedPoem(json)
+    } catch {
+      return null
+    }
+  }
+}

--- a/src/lib/adaptWasmParseJson.ts
+++ b/src/lib/adaptWasmParseJson.ts
@@ -36,6 +36,24 @@ function normalizeFeet(raw: unknown[]): ParsedFoot[] {
   return out
 }
 
+function syllablesFromSyllableNodes(syllNodes: unknown[]): ParsedSyllable[] {
+  const syllables: ParsedSyllable[] = []
+  for (const sn of syllNodes) {
+    if (!sn || typeof sn !== 'object') continue
+    const node = sn as Record<string, unknown>
+    const inner = node.inner
+    const raw = inner !== undefined && inner !== null && typeof inner === 'object' ? inner : sn
+    const syl = normalizeSyllable(raw)
+    if (syl) syllables.push(syl)
+  }
+  return syllables
+}
+
+/** Matches Rust `foot_pattern`: hyphenated Ner/Nirai tokens for one linguistic word. */
+function machineFootPatternFromSyllables(syllables: ParsedSyllable[]): string {
+  return syllables.map((s) => (s.syllable_type === 'Ner' ? 'Ner' : 'Nirai')).join('-')
+}
+
 function normalizeLines(rawLines: unknown, feet: ParsedFoot[]): ParsedLine[] {
   if (!Array.isArray(rawLines) || rawLines.length === 0) {
     if (feet.length === 0) return []
@@ -57,9 +75,58 @@ function normalizeLines(rawLines: unknown, feet: ParsedFoot[]): ParsedLine[] {
   return lines
 }
 
+/** Build `ParsedLine[]` from Rust `ParseResult.poem` (WordNode feet mirror top-level `feet`). */
+function linesFromPoemNode(poem: unknown): ParsedLine[] | null {
+  if (!poem || typeof poem !== 'object') return null
+  const p = poem as Record<string, unknown>
+  const rawLines = p.lines
+  if (!Array.isArray(rawLines) || rawLines.length === 0) return null
+
+  const out: ParsedLine[] = []
+  for (const row of rawLines) {
+    if (!row || typeof row !== 'object') continue
+    const L = row as Record<string, unknown>
+    const line_class = typeof L.line_class === 'string' ? L.line_class : '—'
+    const words = L.words
+    const linguisticWords = L.linguistic_words
+
+    const lineFeet: ParsedFoot[] = []
+
+    if (Array.isArray(words) && words.length > 0) {
+      for (const w of words) {
+        if (!w || typeof w !== 'object') continue
+        const W = w as Record<string, unknown>
+        const foot_type = typeof W.foot_type === 'string' ? W.foot_type : ''
+        const syllNodes = W.syllables
+        if (!Array.isArray(syllNodes)) continue
+        const syllables = syllablesFromSyllableNodes(syllNodes)
+        if (syllables.length === 0 || !foot_type) continue
+        lineFeet.push({ foot_type, syllables })
+      }
+    } else if (Array.isArray(linguisticWords) && linguisticWords.length > 0) {
+      for (const lw of linguisticWords) {
+        if (!lw || typeof lw !== 'object') continue
+        const LW = lw as Record<string, unknown>
+        const syllNodes = LW.syllables
+        if (!Array.isArray(syllNodes)) continue
+        const syllables = syllablesFromSyllableNodes(syllNodes)
+        if (syllables.length === 0) continue
+        lineFeet.push({
+          foot_type: machineFootPatternFromSyllables(syllables),
+          syllables,
+        })
+      }
+    }
+
+    if (lineFeet.length === 0) continue
+    out.push({ line_class, feet: lineFeet })
+  }
+  return out.length > 0 ? out : null
+}
+
 /**
  * Maps Rust `ParseResult` JSON into {@link ParsedPoem}.
- * Rust currently leaves `lines` empty and puts prosody in top-level `feet`; we synthesize one line when needed.
+ * Prefers **`poem.lines[].words`** when present; falls back to **`poem.lines[].linguistic_words`** (same syllables, machine foot pattern); otherwise uses top-level `lines` or a single synthetic line from `feet`.
  */
 export function adaptWasmJsonToParsedPoem(data: unknown): ParsedPoem | null {
   if (!data || typeof data !== 'object') return null
@@ -67,7 +134,9 @@ export function adaptWasmJsonToParsedPoem(data: unknown): ParsedPoem | null {
   if (typeof o.original_text !== 'string' || !Array.isArray(o.syllables)) return null
 
   const feet = Array.isArray(o.feet) ? normalizeFeet(o.feet as unknown[]) : []
-  const lines = normalizeLines(o.lines, feet)
+  const fromPoem = linesFromPoemNode(o.poem)
+  const lines =
+    fromPoem && fromPoem.length > 0 ? fromPoem : normalizeLines(o.lines, feet)
 
   const metreRaw = o.metre_type
   const metre_type =

--- a/src/lib/adaptWasmParseJson.ts
+++ b/src/lib/adaptWasmParseJson.ts
@@ -92,18 +92,7 @@ function linesFromPoemNode(poem: unknown): ParsedLine[] | null {
 
     const lineFeet: ParsedFoot[] = []
 
-    if (Array.isArray(words) && words.length > 0) {
-      for (const w of words) {
-        if (!w || typeof w !== 'object') continue
-        const W = w as Record<string, unknown>
-        const foot_type = typeof W.foot_type === 'string' ? W.foot_type : ''
-        const syllNodes = W.syllables
-        if (!Array.isArray(syllNodes)) continue
-        const syllables = syllablesFromSyllableNodes(syllNodes)
-        if (syllables.length === 0 || !foot_type) continue
-        lineFeet.push({ foot_type, syllables })
-      }
-    } else if (Array.isArray(linguisticWords) && linguisticWords.length > 0) {
+    if (Array.isArray(linguisticWords) && linguisticWords.length > 0) {
       for (const lw of linguisticWords) {
         if (!lw || typeof lw !== 'object') continue
         const LW = lw as Record<string, unknown>
@@ -116,6 +105,17 @@ function linesFromPoemNode(poem: unknown): ParsedLine[] | null {
           syllables,
         })
       }
+    } else if (Array.isArray(words) && words.length > 0) {
+      for (const w of words) {
+        if (!w || typeof w !== 'object') continue
+        const W = w as Record<string, unknown>
+        const foot_type = typeof W.foot_type === 'string' ? W.foot_type : ''
+        const syllNodes = W.syllables
+        if (!Array.isArray(syllNodes)) continue
+        const syllables = syllablesFromSyllableNodes(syllNodes)
+        if (syllables.length === 0 || !foot_type) continue
+        lineFeet.push({ foot_type, syllables })
+      }
     }
 
     if (lineFeet.length === 0) continue
@@ -126,7 +126,7 @@ function linesFromPoemNode(poem: unknown): ParsedLine[] | null {
 
 /**
  * Maps Rust `ParseResult` JSON into {@link ParsedPoem}.
- * Prefers **`poem.lines[].words`** when present; falls back to **`poem.lines[].linguistic_words`** (same syllables, machine foot pattern); otherwise uses top-level `lines` or a single synthetic line from `feet`.
+ * Prefers **`poem.lines[].linguistic_words`** when present (aligned with physical lines); otherwise **`words`**; then top-level `lines` or feet fallback.
  */
 export function adaptWasmJsonToParsedPoem(data: unknown): ParsedPoem | null {
   if (!data || typeof data !== 'object') return null

--- a/src/lib/mapFeetToPhysicalLines.ts
+++ b/src/lib/mapFeetToPhysicalLines.ts
@@ -1,10 +1,16 @@
 import type { ParsedFoot } from '#/types/parsedPoem'
 
-/** Split editor text into physical lines (newlines preserved as structure). */
+/** Split editor text into physical lines — aligned with Rust `str::lines()` on normalized `\n` text. */
 export function physicalPoemLines(poemText: string): string[] {
   const t = poemText.replace(/\r\n/g, '\n')
   if (!t.trim()) return []
-  return t.split('\n')
+  const parts = t.split('\n')
+  // Rust `lines()` does not yield an extra empty line solely because the string ends with `\n`;
+  // JS `split('\n')` adds a trailing `''` in that case → off-by-one vs WASM `ParseResult.lines`.
+  if (parts.length > 1 && parts[parts.length - 1] === '') {
+    parts.pop()
+  }
+  return parts
 }
 
 /**

--- a/src/lib/parserFeetLayout.ts
+++ b/src/lib/parserFeetLayout.ts
@@ -1,10 +1,11 @@
 import type { ParsedFoot, ParsedPoem } from '#/types/parsedPoem'
 
-import { mapFeetToPhysicalLines, physicalPoemLines } from '#/lib/mapFeetToPhysicalLines'
+import { physicalPoemLines } from '#/lib/mapFeetToPhysicalLines'
 
 /**
- * Feet per physical editor line: prefer WASM `parsed.lines` when line counts match;
- * otherwise fall back to character-weighted {@link mapFeetToPhysicalLines}.
+ * Feet per physical editor line: use WASM `parsed.lines` only when line counts match.
+ * On mismatch (mid-edit before debounced parse returns), return **empty** feet per line so we never
+ * slice parser feet onto wrong rows (the old character-weight fallback caused bleed-over).
  */
 export function feetPerPhysicalLine(parsed: ParsedPoem | null, poemText: string): ParsedFoot[][] {
   const physical = physicalPoemLines(poemText)
@@ -15,8 +16,9 @@ export function feetPerPhysicalLine(parsed: ParsedPoem | null, poemText: string)
     return structured.map((ln) => ln.feet)
   }
 
-  const flat = structured.flatMap((ln) => ln.feet)
-  return mapFeetToPhysicalLines(poemText, flat.length > 0 ? flat : [])
+  // Editor line count ≠ parser snapshot (mid-edit debounce, trailing newline drift before fix, etc.).
+  // Do **not** use character-weight `mapFeetToPhysicalLines` — it slices feet across wrong rows.
+  return physical.map(() => [])
 }
 
 /** One UI group per **linguistic word** (one WASM foot). Syllables stay parser order. */

--- a/src/lib/poemTextNormalize.ts
+++ b/src/lib/poemTextNormalize.ts
@@ -1,4 +1,10 @@
-/** Normalize for comparing editor text with `parsed.original_text`. */
+/**
+ * Normalize for comparing editor text with `parsed.original_text`.
+ *
+ * **Do not `trim()` the whole string** — trailing newlines change physical line count
+ * (`"a\\n"` vs `"a\\n\\n"`) but trim collapses them, breaking live-preview cache keys and
+ * causing stale parses to pair with the wrong `physicalPoemLines()` layout.
+ */
 export function normalizePoemText(s: string): string {
-  return s.trim().replace(/\r\n/g, '\n')
+  return s.replace(/\r\n/g, '\n')
 }

--- a/src/types/thepulimaangani_parser-wasm.d.ts
+++ b/src/types/thepulimaangani_parser-wasm.d.ts
@@ -1,0 +1,13 @@
+/** wasm-pack output (`pnpm run build:wasm` → `src/wasm/`); `.js` is gitignored. */
+
+declare module '../wasm/thepulimaangani_parser.js' {
+  export function parse_poem_wasm(poemText: string): string
+
+  export default function init(
+    input:
+      | { module_or_path: string | ArrayBuffer | WebAssembly.Module }
+      | string
+      | ArrayBuffer
+      | WebAssembly.Module,
+  ): Promise<void>
+}

--- a/tamil-seiyul-alagi/src/lib.rs
+++ b/tamil-seiyul-alagi/src/lib.rs
@@ -234,6 +234,43 @@ mod tests {
     }
 
     #[test]
+    fn legacy_flat_lines_include_feet_on_every_physical_line_when_tree_words_sparse() {
+        let mut options = ParseOptions::default();
+        options.alt_scansion = true;
+        options.no_detect = true;
+        options.uyir_u = true;
+
+        let poem = "சுடர்த்தொடீஇ கேளாய் தெருவில்நாம்\nமணற்சிற்றில் காலில் சிதையா அடை\nகோதை பரிந்து வரிப்பந்து கொண்டோ\n";
+        let result = parse_poem(poem, options).expect("parse");
+
+        assert_eq!(result.lines.len(), result.poem.lines.len());
+        for (i, ln) in result.lines.iter().enumerate() {
+            assert!(
+                !ln.feet.is_empty(),
+                "legacy Line {} must carry feet (was collapsing entire poem into line 0 when poem.lines[].words was empty)",
+                i
+            );
+        }
+        let syllables_line0: usize = result.lines[0].feet.iter().map(|f| f.syllables.len()).sum();
+        let total_in_lines: usize = result
+            .lines
+            .iter()
+            .map(|ln| ln.feet.iter().map(|f| f.syllables.len()).sum::<usize>())
+            .sum();
+        assert_eq!(
+            total_in_lines,
+            result.syllables.len(),
+            "legacy lines should account for all syllables once"
+        );
+        assert!(
+            syllables_line0 < result.syllables.len(),
+            "first line must not contain every syllable in the poem (line0={} total={})",
+            syllables_line0,
+            result.syllables.len()
+        );
+    }
+
+    #[test]
     fn empty_input_returns_expected_error() {
         let err = parse_poem("   ", ParseOptions::default()).expect_err("must reject empty input");
         assert!(matches!(err, ParseError::EmptyInput));

--- a/tamil-seiyul-alagi/src/types.rs
+++ b/tamil-seiyul-alagi/src/types.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
-use crate::poem_tree::PoemNode;
+use crate::foot_pattern::foot_pattern;
+use crate::poem_tree::{LinguisticWordNode, PoemNode};
 use crate::{Foot, Linkage, MetreType, Syllable, Talai};
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -57,20 +58,51 @@ pub struct MetreHypothesis {
     pub rule_ids: Vec<RuleId>,
 }
 
+/// Feet for legacy `ParseResult.lines` when `PoemLineNode.words` is empty but
+/// `linguistic_words` holds the same syllables (some lines only populate the linguistic layer).
+fn feet_from_linguistic_words(lws: &[LinguisticWordNode]) -> Vec<Foot> {
+    let mut out = Vec::new();
+    for lw in lws {
+        let syllables: Vec<Syllable> = lw.syllables.iter().map(|s| s.inner.clone()).collect();
+        if syllables.is_empty() {
+            continue;
+        }
+        let foot_type = foot_pattern(&syllables);
+        out.push(Foot {
+            syllables,
+            foot_type,
+        });
+    }
+    out
+}
+
 /// Legacy `Line` rows (`feet` per physical line) derived from the hierarchical `PoemNode`.
+///
+/// Prefer **`linguistic_words`** when present: one foot per whitespace-separated word on that
+/// physical line (matches editor rows). `PoemLineNode.words` can still mis-place feet on line 0
+/// when linkage placement disagrees with line breaks; using words alone collapsed the whole poem
+/// into the first legacy row.
 pub fn flat_lines_from_poem(poem: &PoemNode) -> Vec<Line> {
     poem.lines
         .iter()
-        .map(|ln| Line {
-            line_class: ln.line_class.clone(),
-            feet: ln
-                .words
-                .iter()
-                .map(|w| Foot {
-                    syllables: w.syllables.iter().map(|s| s.inner.clone()).collect(),
-                    foot_type: w.foot_type.clone(),
-                })
-                .collect(),
+        .map(|ln| {
+            let feet = if !ln.linguistic_words.is_empty() {
+                feet_from_linguistic_words(&ln.linguistic_words)
+            } else if !ln.words.is_empty() {
+                ln.words
+                    .iter()
+                    .map(|w| Foot {
+                        syllables: w.syllables.iter().map(|s| s.inner.clone()).collect(),
+                        foot_type: w.foot_type.clone(),
+                    })
+                    .collect()
+            } else {
+                Vec::new()
+            };
+            Line {
+                line_class: ln.line_class.clone(),
+                feet,
+            }
         })
         .collect()
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Fix (first live row showed entire poem)

**Cause:** `flat_lines_from_poem` built legacy `ParseResult.lines` from `PoemLineNode.words`. Line 0 incorrectly accumulated **all** feet (`words` length 11 on line 0); lines 2–3 had **`words: []`** but correct **`linguistic_words`**. The TS `normalizeLines()` path skipped empty legacy rows and folded everything into **one** `ParsedLine`, so row 0 chips showed the whole poem.

**Fix:** Prefer **`linguistic_words`** whenever present (one foot per whitespace-separated word on that physical line); fall back to `words` only when linguistic layer is empty. Same order in `adaptWasmJsonToParsedPoem`.

## Tests

- Rust: `legacy_flat_lines_include_feet_on_every_physical_line_when_tree_words_sparse`
- Vitest: stronger WASM integration checks (`isFirstRowOnlyEntirePoemLayout`, syllable partition), edit variants, `LivePreviewController` cache key (`normalizePoemText`), adapter prefers `linguistic_words` over conflicting `words`.

Rebuild WASM (`pnpm run build:wasm`) after pulling — legacy `lines` in JSON changes shape.

Commit: `8db7309`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc37b7c2-4c7e-493d-ab67-07651df734af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc37b7c2-4c7e-493d-ab67-07651df734af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

