### PR TITLE
refactor(test): shared fixtures for WASM and ParsedPoem tests

### DIFF
--- a/src/lib/__tests__/adaptWasmParseJson.test.ts
+++ b/src/lib/__tests__/adaptWasmParseJson.test.ts
@@ -1,14 +1,19 @@
 import { describe, expect, it } from 'vitest'
 
 import { adaptWasmJsonToParsedPoem } from '#/lib/adaptWasmParseJson'
+import {
+  wasmLinguisticWord,
+  wasmParseJsonFixture,
+  wasmPoem,
+  wasmPoemLine,
+  wasmSyllableNode,
+  wasmWordFoot,
+} from '#/lib/__tests__/fixtures/wasmParseJsonBuilders'
 
 describe('adaptWasmJsonToParsedPoem', () => {
-  it('synthesizes a line from top-level feet when lines is empty', () => {
-    const wasm = {
+  it('synthesizes one legacy line from top-level feet when lines is empty', () => {
+    const wasm = wasmParseJsonFixture({
       original_text: 'அஃகு',
-      normalized_text: 'அஃகு',
-      letter_count: 3,
-      vikalpa_count: 0,
       syllables: [{ text: 'அஃ', syllable_type: 'Ner' }],
       feet: [
         {
@@ -19,11 +24,10 @@ describe('adaptWasmJsonToParsedPoem', () => {
           ],
         },
       ],
-      linkage: [],
       lines: [],
       metre_type: 'Venpaa',
       errors: [],
-    }
+    })
 
     const out = adaptWasmJsonToParsedPoem(wasm)
     expect(out).not.toBeNull()
@@ -33,42 +37,33 @@ describe('adaptWasmJsonToParsedPoem', () => {
     expect(out!.lines[0]!.feet[0]!.syllables[0]!.syllable_type).toBe('Ner')
   })
 
-  it('prefers linguistic_words over words when both present (misplaced tree feet)', () => {
-    const wasm = {
+  it('prefers poem.lines[].linguistic_words over words when both are present', () => {
+    const wasm = wasmParseJsonFixture({
       original_text: 'a\nb',
       syllables: [],
       feet: [],
       lines: [],
-      poem: {
-        lines: [
-          {
-            line_class: '—',
-            line_index: 0,
-            words: [
-              {
-                foot_type: 'Ner-Ner',
-                foot_index_global: 0,
-                word_index_in_line: 0,
-                syllables: [
-                  { inner: { text: 'whole', syllable_type: 'Ner', alt_split: false } },
-                  { inner: { text: 'poem', syllable_type: 'Ner', alt_split: false } },
-                ],
-              },
-            ],
-            linguistic_words: [
-              {
-                word_index_in_line: 0,
-                syllables: [{ inner: { text: 'only', syllable_type: 'Ner', alt_split: false } }],
-              },
-            ],
-          },
-        ],
-      },
-      metre_type: null,
-      letter_count: 0,
-      vikalpa_count: 0,
-      errors: [],
-    }
+      poem: wasmPoem([
+        wasmPoemLine({
+          line_index: 0,
+          words: [
+            wasmWordFoot({
+              foot_type: 'Ner-Ner',
+              syllableNodes: [
+                wasmSyllableNode('whole', 'Ner'),
+                wasmSyllableNode('poem', 'Ner'),
+              ],
+            }),
+          ],
+          linguistic_words: [
+            wasmLinguisticWord({
+              word_index_in_line: 0,
+              syllableNodes: [wasmSyllableNode('only', 'Ner')],
+            }),
+          ],
+        }),
+      ]),
+    })
 
     const out = adaptWasmJsonToParsedPoem(wasm)
     expect(out).not.toBeNull()
@@ -76,45 +71,35 @@ describe('adaptWasmJsonToParsedPoem', () => {
     expect(out!.lines[0]!.feet[0]!.syllables[0]!.text).toBe('only')
   })
 
-  it('extracts per-line feet from nested poem.words when top-level lines is empty', () => {
-    const wasm = {
+  it('builds one ParsedLine per poem.lines[] row from words when linguistic_words absent', () => {
+    const wasm = wasmParseJsonFixture({
       original_text: 'a\nb',
       syllables: [],
       feet: [],
       lines: [],
-      poem: {
-        lines: [
-          {
-            line_class: '—',
-            line_index: 0,
-            words: [
-              {
-                foot_type: 'Ner',
-                foot_index_global: 0,
-                word_index_in_line: 0,
-                syllables: [{ inner: { text: 'x', syllable_type: 'Ner', alt_split: false } }],
-              },
-            ],
-          },
-          {
-            line_class: '—',
-            line_index: 1,
-            words: [
-              {
-                foot_type: 'Nirai',
-                foot_index_global: 1,
-                word_index_in_line: 0,
-                syllables: [{ inner: { text: 'y', syllable_type: 'Nirai', alt_split: false } }],
-              },
-            ],
-          },
-        ],
-      },
-      metre_type: null,
-      letter_count: 0,
-      vikalpa_count: 0,
-      errors: [],
-    }
+      poem: wasmPoem([
+        wasmPoemLine({
+          line_index: 0,
+          words: [
+            wasmWordFoot({
+              foot_type: 'Ner',
+              syllableNodes: [wasmSyllableNode('x', 'Ner')],
+              foot_index_global: 0,
+            }),
+          ],
+        }),
+        wasmPoemLine({
+          line_index: 1,
+          words: [
+            wasmWordFoot({
+              foot_type: 'Nirai',
+              syllableNodes: [wasmSyllableNode('y', 'Nirai')],
+              foot_index_global: 1,
+            }),
+          ],
+        }),
+      ]),
+    })
 
     const out = adaptWasmJsonToParsedPoem(wasm)
     expect(out).not.toBeNull()
@@ -123,47 +108,34 @@ describe('adaptWasmJsonToParsedPoem', () => {
     expect(out!.lines[1]!.feet[0]!.syllables[0]!.text).toBe('y')
   })
 
-  it('uses linguistic_words when words is empty (mirrors WASM lines 2+)', () => {
-    const wasm = {
+  it('uses linguistic_words on a row when words is empty (WASM lines 2+)', () => {
+    const wasm = wasmParseJsonFixture({
       original_text: 'a\nb',
       syllables: [],
       feet: [],
       lines: [],
-      poem: {
-        lines: [
-          {
-            line_class: '—',
-            line_index: 0,
-            words: [
-              {
-                foot_type: 'Ner',
-                foot_index_global: 0,
-                word_index_in_line: 0,
-                syllables: [{ inner: { text: 'x', syllable_type: 'Ner', alt_split: false } }],
-              },
-            ],
-          },
-          {
-            line_class: '—',
-            line_index: 1,
-            words: [],
-            linguistic_words: [
-              {
-                word_index_in_line: 0,
-                syllables: [
-                  { inner: { text: 'அ', syllable_type: 'Ner', alt_split: false } },
-                  { inner: { text: 'ஆ', syllable_type: 'Nirai', alt_split: false } },
-                ],
-              },
-            ],
-          },
-        ],
-      },
-      metre_type: null,
-      letter_count: 0,
-      vikalpa_count: 0,
-      errors: [],
-    }
+      poem: wasmPoem([
+        wasmPoemLine({
+          line_index: 0,
+          words: [
+            wasmWordFoot({
+              foot_type: 'Ner',
+              syllableNodes: [wasmSyllableNode('x', 'Ner')],
+            }),
+          ],
+        }),
+        wasmPoemLine({
+          line_index: 1,
+          words: [],
+          linguistic_words: [
+            wasmLinguisticWord({
+              word_index_in_line: 0,
+              syllableNodes: [wasmSyllableNode('அ', 'Ner'), wasmSyllableNode('ஆ', 'Nirai')],
+            }),
+          ],
+        }),
+      ]),
+    })
 
     const out = adaptWasmJsonToParsedPoem(wasm)
     expect(out).not.toBeNull()
@@ -172,17 +144,15 @@ describe('adaptWasmJsonToParsedPoem', () => {
     expect(out!.lines[1]!.feet[0]!.syllables).toHaveLength(2)
   })
 
-  it('accepts null metre_type from Rust Option::None', () => {
-    const wasm = {
+  it('maps null metre_type from Rust to em dash', () => {
+    const wasm = wasmParseJsonFixture({
       original_text: 'ab',
-      letter_count: 2,
-      vikalpa_count: 0,
       syllables: [],
       feet: [],
       lines: [],
       metre_type: null,
-      errors: [],
-    }
+      letter_count: 2,
+    })
 
     const out = adaptWasmJsonToParsedPoem(wasm)
     expect(out).not.toBeNull()

--- a/src/lib/__tests__/fixtures/livePreviewLayoutHelpers.ts
+++ b/src/lib/__tests__/fixtures/livePreviewLayoutHelpers.ts
@@ -1,0 +1,36 @@
+import type { ParsedFoot } from '#/types/parsedPoem'
+
+import type { feetPerPhysicalLine } from '#/lib/parserFeetLayout'
+
+type FeetBuckets = ReturnType<typeof feetPerPhysicalLine>
+
+export function totalFeet(buckets: FeetBuckets): number {
+  return buckets.reduce((n, row) => n + row.length, 0)
+}
+
+export function totalSyllablesFromBuckets(buckets: FeetBuckets): number {
+  return buckets.reduce(
+    (n, row) => n + row.reduce((m, ft) => m + ft.syllables.length, 0),
+    0,
+  )
+}
+
+export function flattenFootSyllableTexts(lineFeet: ParsedFoot[]): string[] {
+  return lineFeet.flatMap((ft) => ft.syllables.map((s) => s.text))
+}
+
+/**
+ * Detects the “whole poem syllables only on row 0” bug when physical rows > 1
+ * but chips only appear on the first row.
+ */
+export function isFirstRowOnlyEntirePoemLayout(
+  buckets: FeetBuckets,
+  totalSyllablesInParse: number,
+): boolean {
+  if (buckets.length < 2) return false
+  const s0 = flattenFootSyllableTexts(buckets[0] ?? []).length
+  const sRest = buckets
+    .slice(1)
+    .reduce((n, row) => n + flattenFootSyllableTexts(row).length, 0)
+  return s0 > 0 && sRest === 0 && s0 === totalSyllablesInParse && totalSyllablesInParse > 4
+}

--- a/src/lib/__tests__/fixtures/parsedPoemBuilders.ts
+++ b/src/lib/__tests__/fixtures/parsedPoemBuilders.ts
@@ -1,0 +1,41 @@
+import type { ParsedFoot, ParsedLine, ParsedPoem, ParsedSyllable } from '#/types/parsedPoem'
+
+const defaultSyllables: unknown[] = []
+
+/** One syllable chip as the UI consumes it. */
+export function parsedSyllable(text: string, syllable_type = 'Ner'): ParsedSyllable {
+  return { text, syllable_type }
+}
+
+/** One foot = one linguistic word worth of syllables. */
+export function parsedFoot(foot_type: string, syllables: ParsedSyllable[]): ParsedFoot {
+  return { foot_type, syllables }
+}
+
+/** Shorthand: single-syllable foot. */
+export function parsedFootNer(text: string): ParsedFoot {
+  return parsedFoot('Ner', [parsedSyllable(text, 'Ner')])
+}
+
+export function parsedLine(feet: ParsedFoot[], line_class = '—'): ParsedLine {
+  return { line_class, feet }
+}
+
+type ParsedPoemCore = Omit<ParsedPoem, 'errors'> & { errors?: string[] }
+
+/**
+ * Minimal valid {@link ParsedPoem} for layout / adapter tests.
+ * Supply `lines` and `original_text`; everything else gets stable defaults.
+ */
+export function parsedPoem(overrides: Partial<ParsedPoemCore> & Pick<ParsedPoem, 'lines'>): ParsedPoem {
+  const { errors, ...rest } = overrides
+  const base: ParsedPoem = {
+    original_text: rest.original_text ?? '',
+    metre_type: rest.metre_type ?? '—',
+    letter_count: rest.letter_count ?? 0,
+    vikalpa_count: rest.vikalpa_count ?? 0,
+    syllables: rest.syllables ?? defaultSyllables,
+    lines: rest.lines,
+  }
+  return errors != null && errors.length > 0 ? { ...base, errors } : base
+}

--- a/src/lib/__tests__/fixtures/sampleTamilPoems.ts
+++ b/src/lib/__tests__/fixtures/sampleTamilPoems.ts
@@ -1,0 +1,5 @@
+/** Shared multi-line Tamil sample used by live-preview / WASM layout tests. */
+export const SAMPLE_POEM_THREE_LINES = `சுடர்த்தொடீஇ கேளாய் தெருவில்நாம்
+மணற்சிற்றில் காலில் சிதையா அடை
+கோதை பரிந்து வரிப்பந்து கொண்டோ
+`

--- a/src/lib/__tests__/fixtures/wasmParseJsonBuilders.ts
+++ b/src/lib/__tests__/fixtures/wasmParseJsonBuilders.ts
@@ -1,0 +1,105 @@
+/**
+ * Builders for JSON shapes produced by `parse_poem_wasm` / consumed by {@link adaptWasmJsonToParsedPoem}.
+ * Keeps tests readable and structurally consistent with serde field names.
+ */
+
+/** Syllable node under `WordNode` / `LinguisticWordNode` in Rust JSON. */
+export function wasmSyllableNode(text: string, syllable_type: 'Ner' | 'Nirai' = 'Ner') {
+  return { inner: { text, syllable_type, alt_split: false as const } }
+}
+
+export function wasmWordFoot(opts: {
+  foot_type: string
+  syllableNodes: ReturnType<typeof wasmSyllableNode>[]
+  foot_index_global?: number
+  word_index_in_line?: number
+}) {
+  const {
+    foot_type,
+    syllableNodes,
+    foot_index_global = 0,
+    word_index_in_line = 0,
+  } = opts
+  return {
+    foot_type,
+    foot_index_global,
+    word_index_in_line,
+    syllables: syllableNodes,
+  }
+}
+
+export function wasmLinguisticWord(opts: {
+  word_index_in_line: number
+  syllableNodes: ReturnType<typeof wasmSyllableNode>[]
+}) {
+  return {
+    word_index_in_line: opts.word_index_in_line,
+    syllables: opts.syllableNodes,
+  }
+}
+
+export function wasmPoemLine(opts: {
+  line_index: number
+  line_class?: string
+  words?: ReturnType<typeof wasmWordFoot>[]
+  linguistic_words?: ReturnType<typeof wasmLinguisticWord>[]
+}) {
+  return {
+    line_class: opts.line_class ?? '—',
+    line_index: opts.line_index,
+    words: opts.words ?? [],
+    linguistic_words: opts.linguistic_words ?? [],
+  }
+}
+
+export function wasmPoem(lines: ReturnType<typeof wasmPoemLine>[]) {
+  return { lines }
+}
+
+type WasmJsonFixtureInput = {
+  original_text: string
+  syllables?: unknown[]
+  feet?: unknown[]
+  lines?: unknown[]
+  poem?: unknown
+  metre_type?: string | null
+  letter_count?: number
+  vikalpa_count?: number
+  errors?: unknown[]
+}
+
+/**
+ * Full top-level parse result object (still typed as `unknown` for the adapter under test).
+ */
+export function wasmParseJsonFixture(input: WasmJsonFixtureInput): unknown {
+  return {
+    original_text: input.original_text,
+    normalized_text: input.original_text,
+    syllables: input.syllables ?? [],
+    feet: input.feet ?? [],
+    lines: input.lines ?? [],
+    linkage: [],
+    talai: [],
+    metre_type: input.metre_type ?? null,
+    letter_count: input.letter_count ?? 0,
+    vikalpa_count: input.vikalpa_count ?? 0,
+    errors: input.errors ?? [],
+    ...(input.poem !== undefined ? { poem: input.poem } : {}),
+  }
+}
+
+/** Minimal WASM JSON for {@link LivePreviewController} tests (fields the adapter reads). */
+export function wasmLivePreviewControllerStub(canonText: string): unknown {
+  return wasmParseJsonFixture({
+    original_text: canonText,
+    syllables: [{ text: 'a', syllable_type: 'Ner' }],
+    feet: [{ foot_type: 'Ner', syllables: [{ text: 'a', syllable_type: 'Ner' }] }],
+    lines: [
+      {
+        line_class: '—',
+        feet: [{ foot_type: 'Ner', syllables: [{ text: 'a', syllable_type: 'Ner' }] }],
+      },
+    ],
+    poem: { lines: [], syllables_flat: [], normalized_text: canonText, linkage: [] },
+  })
+}

--- a/src/lib/__tests__/livePreviewController.test.ts
+++ b/src/lib/__tests__/livePreviewController.test.ts
@@ -5,27 +5,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { LivePreviewController } from '#/lib/livePreviewController'
 import { normalizePoemText } from '#/lib/poemTextNormalize'
+import { wasmLivePreviewControllerStub } from '#/lib/__tests__/fixtures/wasmParseJsonBuilders'
 import type { LivePreviewState } from '#/types/livePreview'
 
 vi.mock('#/lib/wasmParse', () => ({
   runWasmParse: vi.fn(async (text: string) => {
-    const norm = text.replace(/\r\n/g, '\n')
-    return JSON.stringify({
-      original_text: norm,
-      normalized_text: norm,
-      letter_count: 0,
-      vikalpa_count: 0,
-      syllables: [{ text: 'a', syllable_type: 'Ner' }],
-      feet: [{ foot_type: 'Ner', syllables: [{ text: 'a', syllable_type: 'Ner' }] }],
-      lines: [
-        { line_class: '—', feet: [{ foot_type: 'Ner', syllables: [{ text: 'a', syllable_type: 'Ner' }] }] },
-      ],
-      poem: { lines: [], syllables_flat: [], normalized_text: norm, linkage: [] },
-      linkage: [],
-      talai: [],
-      metre_type: null,
-      errors: [],
-    })
+    const canon = text.replace(/\r\n/g, '\n')
+    return JSON.stringify(wasmLivePreviewControllerStub(canon))
   }),
 }))
 
@@ -39,7 +25,7 @@ describe('LivePreviewController', () => {
     vi.useRealTimers()
   })
 
-  it('uses normalizePoemText for cache; trailing newline vs none are different parses', async () => {
+  it('cache key: trailing newline vs none yields different normalizePoemText(parsed.original_text)', async () => {
     const states: LivePreviewState[] = []
     const c = new LivePreviewController(0, (s) => {
       states.push(structuredClone(s))

--- a/src/lib/__tests__/livePreviewEditScenarios.test.ts
+++ b/src/lib/__tests__/livePreviewEditScenarios.test.ts
@@ -1,101 +1,49 @@
 /**
- * Live preview / layout contracts under aggressive poem edits.
+ * Live preview layout: physical editor lines ↔ `parsed.lines` ↔ `feetPerPhysicalLine`.
  *
- * **Goals**
- * - Document expected behaviour: editor physical lines ↔ WASM `parsed.lines` ↔ `feetPerPhysicalLine`.
- * - Integration tests run **only** when a WASM bundle exists (`pnpm run build:wasm` → `public/wasm/` or `src/wasm/`).
- *
- * **Failures here are learning signals** — fix implementation until these pass in CI (after WASM build step).
+ * WASM-backed tests run only when a bundle exists (`pnpm run build:wasm`).
  */
 
-import { describe, expect, it, beforeAll } from 'vitest'
+import { beforeAll, describe, expect, it } from 'vitest'
 
 import { feetPerPhysicalLine, groupsFromFeet } from '#/lib/parserFeetLayout'
-import { normalizePoemText } from '#/lib/poemTextNormalize'
 import { physicalPoemLines } from '#/lib/mapFeetToPhysicalLines'
-import type { ParsedPoem } from '#/types/parsedPoem'
-
+import { normalizePoemText } from '#/lib/poemTextNormalize'
+import {
+  flattenFootSyllableTexts,
+  isFirstRowOnlyEntirePoemLayout,
+  totalFeet,
+  totalSyllablesFromBuckets,
+} from '#/lib/__tests__/fixtures/livePreviewLayoutHelpers'
+import {
+  parsedFoot,
+  parsedLine,
+  parsedPoem,
+  parsedSyllable,
+} from '#/lib/__tests__/fixtures/parsedPoemBuilders'
+import { SAMPLE_POEM_THREE_LINES } from '#/lib/__tests__/fixtures/sampleTamilPoems'
 import {
   createWasmParsePoem,
   isWasmPkgBuilt,
   type WasmParseFn,
 } from '#/lib/__tests__/wasmParseHarness'
 
-/** Same poem shape as mobile repro — multi-line Tamil with spaces & newline endings */
-export const SAMPLE_POEM_THREE_LINES = `சுடர்த்தொடீஇ கேளாய் தெருவில்நாம்
-மணற்சிற்றில் காலில் சிதையா அடை
-கோதை பரிந்து வரிப்பந்து கொண்டோ
-`
-
-function totalFeet(buckets: ReturnType<typeof feetPerPhysicalLine>): number {
-  return buckets.reduce((n, row) => n + row.length, 0)
-}
-
-function totalSyllablesFromBuckets(buckets: ReturnType<typeof feetPerPhysicalLine>): number {
-  return buckets.reduce(
-    (n, row) => n + row.reduce((m, ft) => m + ft.syllables.length, 0),
-    0,
-  )
-}
-
-function flattenFootSyllableTexts(lineFeet: ReturnType<typeof feetPerPhysicalLine>[number]): string[] {
-  return lineFeet.flatMap((ft) => ft.syllables.map((s) => s.text))
-}
-
-/**
- * When legacy `lines` collapses the whole poem into `lines[0]`, the first row has chips and later rows are empty
- * (mobile bug: "first line shows entire poem"). Multi-line + non-empty first row + empty rest + many syllables only on row0.
- */
-function isFirstRowOnlyEntirePoemLayout(
-  buckets: ReturnType<typeof feetPerPhysicalLine>,
-  totalSyllablesInParse: number,
-): boolean {
-  if (buckets.length < 2) return false
-  const s0 = flattenFootSyllableTexts(buckets[0] ?? []).length
-  const sRest = buckets
-    .slice(1)
-    .reduce((n, row) => n + flattenFootSyllableTexts(row).length, 0)
-  return s0 > 0 && sRest === 0 && s0 === totalSyllablesInParse && totalSyllablesInParse > 4
-}
-
 describe('live preview layout (no WASM)', () => {
-  it('physicalPoemLines count matches structured.lines → feet buckets get syllables', () => {
+  it('when physical line count equals parsed.lines, feet and groups are populated', () => {
     const poemText = 'ஒன்று இரண்டு\nமூன்று நான்கு\n'
-    const parsed: ParsedPoem = {
+    const parsed = parsedPoem({
       original_text: poemText,
-      metre_type: '—',
-      letter_count: 0,
-      vikalpa_count: 0,
-      syllables: [],
       lines: [
-        {
-          line_class: '—',
-          feet: [
-            {
-              foot_type: 'Ner-Ner',
-              syllables: [{ text: 'ஒன்று', syllable_type: 'Ner' }],
-            },
-            {
-              foot_type: 'Nirai',
-              syllables: [{ text: 'இரண்டு', syllable_type: 'Nirai' }],
-            },
-          ],
-        },
-        {
-          line_class: '—',
-          feet: [
-            {
-              foot_type: 'Ner',
-              syllables: [{ text: 'மூன்று', syllable_type: 'Ner' }],
-            },
-            {
-              foot_type: 'Ner',
-              syllables: [{ text: 'நான்கு', syllable_type: 'Ner' }],
-            },
-          ],
-        },
+        parsedLine([
+          parsedFoot('Ner-Ner', [parsedSyllable('ஒன்று', 'Ner')]),
+          parsedFoot('Nirai', [parsedSyllable('இரண்டு', 'Nirai')]),
+        ]),
+        parsedLine([
+          parsedFoot('Ner', [parsedSyllable('மூன்று', 'Ner')]),
+          parsedFoot('Ner', [parsedSyllable('நான்கு', 'Ner')]),
+        ]),
       ],
-    }
+    })
 
     expect(physicalPoemLines(poemText).length).toBe(parsed.lines.length)
 
@@ -109,21 +57,12 @@ describe('live preview layout (no WASM)', () => {
     expect(row0.every((g) => g.syllables.length > 0)).toBe(true)
   })
 
-  it('when editor lines ≠ structured.lines, buckets are empty (no wrong-row bleed)', () => {
+  it('when physical line count ≠ parsed.lines, every bucket is empty', () => {
     const poemText = 'a\nb\n'
-    const parsed: ParsedPoem = {
+    const parsed = parsedPoem({
       original_text: poemText,
-      metre_type: '—',
-      letter_count: 0,
-      vikalpa_count: 0,
-      syllables: [],
-      lines: [
-        {
-          line_class: '—',
-          feet: [{ foot_type: 'Ner', syllables: [{ text: 'x', syllable_type: 'Ner' }] }],
-        },
-      ],
-    }
+      lines: [parsedLine([parsedFoot('Ner', [parsedSyllable('x', 'Ner')])])],
+    })
     expect(physicalPoemLines(poemText).length).toBe(2)
     expect(parsed.lines.length).toBe(1)
 
@@ -131,7 +70,7 @@ describe('live preview layout (no WASM)', () => {
     expect(buckets.every((row) => row.length === 0)).toBe(true)
   })
 
-  it('normalizePoemText distinguishes drafts that differ only by trailing newlines', () => {
+  it('normalizePoemText differs for drafts that only differ by trailing newlines', () => {
     expect(normalizePoemText('foo\n')).not.toBe(normalizePoemText('foo\n\n'))
   })
 })
@@ -143,7 +82,7 @@ describe.skipIf(!isWasmPkgBuilt())('live preview + WASM integration', () => {
     parsePoem = await createWasmParsePoem()
   })
 
-  it('parses sample poem and returns structured lines count matching physicalPoemLines', async () => {
+  it('sample poem: physical lines match WASM lines; syllables not collapsed to row 0', async () => {
     const text = SAMPLE_POEM_THREE_LINES
     const parsed = await parsePoem(text)
     expect(parsed).not.toBeNull()
@@ -151,10 +90,9 @@ describe.skipIf(!isWasmPkgBuilt())('live preview + WASM integration', () => {
 
     const phys = physicalPoemLines(text)
     expect(p.lines.length).toBeGreaterThan(0)
-    expect(
-      phys.length,
-      'editor physical line count must equal WASM ParseResult.lines length for chip sync',
-    ).toBe(p.lines.length)
+    expect(phys.length, 'editor lines must match WASM ParseResult.lines for chip sync').toBe(
+      p.lines.length,
+    )
 
     const buckets = feetPerPhysicalLine(p, text)
     expect(totalFeet(buckets)).toBeGreaterThan(0)
@@ -163,21 +101,20 @@ describe.skipIf(!isWasmPkgBuilt())('live preview + WASM integration', () => {
     const s0 = flattenFootSyllableTexts(buckets[0] ?? []).length
     expect(
       s0 < p.syllables.length,
-      'first physical row must not show every syllable of the poem (regression: collapsed legacy lines)',
+      'first row must not contain every syllable (regression: collapsed legacy lines)',
     ).toBe(true)
     expect(isFirstRowOnlyEntirePoemLayout(buckets, p.syllables.length)).toBe(false)
     expect(totalSyllablesFromBuckets(buckets)).toBe(p.syllables.length)
 
     for (let i = 0; i < buckets.length; i++) {
       const groups = groupsFromFeet(buckets[i] ?? [])
-      expect(
-        groups.length,
-        `line ${i} should show at least one word group when layout matches`,
-      ).toBeGreaterThan(0)
+      expect(groups.length, `line ${i} needs at least one word group when aligned`).toBeGreaterThan(
+        0,
+      )
     }
   })
 
-  it('every step in an aggressive edit sequence stays layout-aligned or intentionally empties chips', async () => {
+  it('edit sequence: aligned steps show syllables; misaligned steps use empty buckets', async () => {
     const steps: string[] = [
       SAMPLE_POEM_THREE_LINES.trim(),
       SAMPLE_POEM_THREE_LINES,
@@ -202,26 +139,22 @@ describe.skipIf(!isWasmPkgBuilt())('live preview + WASM integration', () => {
       expect(buckets.length).toBe(phys.length)
 
       if (phys.length === parsed.lines.length) {
-        expect(
-          totalSyllablesFromBuckets(buckets),
-          `step ${step}: aligned layout should surface syllables`,
-        ).toBeGreaterThan(0)
+        expect(totalSyllablesFromBuckets(buckets), `step ${step}: aligned layout surfaces syllables`).toBeGreaterThan(0)
       } else {
         expect(
           buckets.every((r) => r.length === 0),
-          `step ${step}: mismatched counts should avoid placing feet on wrong rows`,
+          `step ${step}: misaligned counts must not place feet on wrong rows`,
         ).toBe(true)
       }
     }
   })
 
-  it('multi-line sample: total syllables partition across rows (not collapsed into row 0)', async () => {
+  it('multi-line sample: syllable count partitions across rows', async () => {
     const text = SAMPLE_POEM_THREE_LINES
     const parsed = await parsePoem(text)
     expect(parsed).not.toBeNull()
     const buckets = feetPerPhysicalLine(parsed!, text)
-    const tot = totalSyllablesFromBuckets(buckets)
-    expect(tot).toBe(parsed!.syllables.length)
+    expect(totalSyllablesFromBuckets(buckets)).toBe(parsed!.syllables.length)
     const maxSingleRow = Math.max(
       ...buckets.map((row) => flattenFootSyllableTexts(row).length),
       0,
@@ -229,7 +162,7 @@ describe.skipIf(!isWasmPkgBuilt())('live preview + WASM integration', () => {
     expect(maxSingleRow).toBeLessThan(parsed!.syllables.length)
   })
 
-  it('edit simulations: deleting lines / fragments never stacks entire poem on physical row 0 when counts align', async () => {
+  it('deleting lines or fragments: no “whole poem on row 0” when counts stay aligned', async () => {
     const variants = [
       SAMPLE_POEM_THREE_LINES.split('\n').slice(0, 2).join('\n') + '\n',
       SAMPLE_POEM_THREE_LINES.replace(/\n.+$/s, ''),
@@ -248,19 +181,11 @@ describe.skipIf(!isWasmPkgBuilt())('live preview + WASM integration', () => {
     }
   })
 
-  it('adaptWasmJsonToParsedPoem round-trip matches parse_poem_wasm JSON shape', async () => {
+  it('WASM JSON round-trips through adaptWasmJsonToParsedPoem (harness contract)', async () => {
     const text = SAMPLE_POEM_THREE_LINES
     const parsed = await parsePoem(text)
     expect(parsed).not.toBeNull()
     expect(parsed!.original_text).toBeTruthy()
     expect(Array.isArray(parsed!.lines)).toBe(true)
-  })
-})
-
-describe('live preview controller cache key contract (documented behaviour)', () => {
-  it('same normalizePoemText(editor) === normalizePoemText(parsed.original_text) implies cache hit path', () => {
-    const editor = 'அஃ கு '
-    const parsedNorm = normalizePoemText(editor)
-    expect(parsedNorm).toBe(normalizePoemText(editor))
   })
 })

--- a/src/lib/__tests__/parserFeetLayout.test.ts
+++ b/src/lib/__tests__/parserFeetLayout.test.ts
@@ -1,57 +1,38 @@
 import { describe, expect, it } from 'vitest'
 
 import { feetPerPhysicalLine, groupsFromFeet } from '#/lib/parserFeetLayout'
-import type { ParsedPoem } from '#/types/parsedPoem'
-
-function poem(lines: ParsedPoem['lines']): ParsedPoem {
-  return {
-    original_text: '',
-    metre_type: '—',
-    letter_count: 0,
-    vikalpa_count: 0,
-    syllables: [],
-    lines,
-  }
-}
+import {
+  parsedFoot,
+  parsedLine,
+  parsedPoem,
+  parsedSyllable,
+} from '#/lib/__tests__/fixtures/parsedPoemBuilders'
 
 describe('feetPerPhysicalLine', () => {
-  it('uses structured lines when count matches physical lines', () => {
-    const p = poem([
-      {
-        line_class: '—',
-        feet: [
-          {
-            foot_type: 'Ner-Ner',
-            syllables: [{ text: 'ab', syllable_type: 'Ner' }],
-          },
-        ],
-      },
-      {
-        line_class: '—',
-        feet: [
-          {
-            foot_type: 'Nirai',
-            syllables: [{ text: 'cd', syllable_type: 'Nirai' }],
-          },
-        ],
-      },
-    ])
-    const text = 'first line\nsecond'
-    const buckets = feetPerPhysicalLine(p, text)
+  it('uses structured lines when physical line count matches parsed.lines', () => {
+    const p = parsedPoem({
+      lines: [
+        parsedLine([
+          parsedFoot('Ner-Ner', [parsedSyllable('ab', 'Ner')]),
+        ]),
+        parsedLine([
+          parsedFoot('Nirai', [parsedSyllable('cd', 'Nirai')]),
+        ]),
+      ],
+    })
+    const poemText = 'first line\nsecond'
+    const buckets = feetPerPhysicalLine(p, poemText)
     expect(buckets).toHaveLength(2)
     expect(buckets[0]![0]!.syllables[0]!.text).toBe('ab')
     expect(buckets[1]![0]!.syllables[0]!.text).toBe('cd')
   })
 
-  it('returns empty feet per line when parser line count mismatches (avoid wrong-row slices)', () => {
-    const p = poem([
-      {
-        line_class: '—',
-        feet: [{ foot_type: 'Ner', syllables: [{ text: 'only', syllable_type: 'Ner' }] }],
-      },
-    ])
-    const text = 'line one\nline two'
-    const buckets = feetPerPhysicalLine(p, text)
+  it('returns empty feet per line when counts differ (no wrong-row slices)', () => {
+    const p = parsedPoem({
+      lines: [parsedLine([parsedFoot('Ner', [parsedSyllable('only', 'Ner')])])],
+    })
+    const poemText = 'line one\nline two'
+    const buckets = feetPerPhysicalLine(p, poemText)
     expect(buckets).toHaveLength(2)
     expect(buckets[0]).toEqual([])
     expect(buckets[1]).toEqual([])
@@ -59,22 +40,10 @@ describe('feetPerPhysicalLine', () => {
 })
 
 describe('groupsFromFeet', () => {
-  it('one group per foot with concatenated word label', () => {
+  it('emits one UI group per foot; word label is syllable texts concatenated', () => {
     const g = groupsFromFeet([
-      {
-        foot_type: 'Ner-Nirai',
-        syllables: [
-          { text: 'நண்', syllable_type: 'Ner' },
-          { text: 'ணு', syllable_type: 'Nirai' },
-        ],
-      },
-      {
-        foot_type: 'Ner-Nirai',
-        syllables: [
-          { text: 'வார்', syllable_type: 'Ner' },
-          { text: 'வினை', syllable_type: 'Nirai' },
-        ],
-      },
+      parsedFoot('Ner-Nirai', [parsedSyllable('நண்', 'Ner'), parsedSyllable('ணு', 'Nirai')]),
+      parsedFoot('Ner-Nirai', [parsedSyllable('வார்', 'Ner'), parsedSyllable('வினை', 'Nirai')]),
     ])
     expect(g).toHaveLength(2)
     expect(g[0]!.word).toBe('நண்ணு')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Frontend prosody tests inlined large JSON blobs and duplicated `ParsedPoem` shapes, which made it hard to see what structure was intentional versus accidental noise.

## Changes

- Add **`src/lib/__tests__/fixtures/`** with small, typed builders:
  - **`parsedPoemBuilders.ts`** — `parsedPoem`, `parsedLine`, `parsedFoot`, `parsedSyllable` for layout tests.
  - **`wasmParseJsonBuilders.ts`** — `wasmSyllableNode`, `wasmWordFoot`, `wasmLinguisticWord`, `wasmPoemLine`, `wasmPoem`, `wasmParseJsonFixture`, plus **`wasmLivePreviewControllerStub`** for the controller mock.
  - **`livePreviewLayoutHelpers.ts`** — `totalFeet`, `totalSyllablesFromBuckets`, `flattenFootSyllableTexts`, `isFirstRowOnlyEntirePoemLayout` (moved out of the scenario file).
  - **`sampleTamilPoems.ts`** — shared `SAMPLE_POEM_THREE_LINES`.
- Refactor **`adaptWasmParseJson.test.ts`**, **`parserFeetLayout.test.ts`**, **`livePreviewEditScenarios.test.ts`**, **`livePreviewController.test.ts`** to use these helpers; rename a few cases for clarity.
- Remove the tautological **`normalizePoemText(editor) === normalizePoemText(editor)`** block.
- Rename the misleading “round-trip” WASM test to describe the **harness** (`adaptWasmJsonToParsedPoem` inside `createWasmParsePoem`), not a second round-trip assertion.

## Verification

`node` / `pnpm` were unavailable in the agent sandbox; please run locally:

`pnpm run typecheck` and `pnpm run test:frontend` (with `pnpm run build:wasm` if you want WASM integration tests un-skipped).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6f765198-808e-4c1f-9512-4a9dfaff0a15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6f765198-808e-4c1f-9512-4a9dfaff0a15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

