### PR TITLE
test: live preview fixtures from real ParseResult JSON

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "preview": "vite preview",
     "test": "pnpm run test:rust && pnpm run test:frontend",
     "test:rust": "cd tamil-seiyul-alagi  && cargo test",
+    "dump:test-fixture": "cd tamil-seiyul-alagi && cargo run --example dump_live_preview_fixture",
     "test:frontend": "vitest run",
     "test:watch": "vitest",
     "lint": "echo 'No linter configured yet'",

--- a/src/lib/__tests__/fixtures/samplePoemThreeLines.fixture.ts
+++ b/src/lib/__tests__/fixtures/samplePoemThreeLines.fixture.ts
@@ -1,0 +1,50 @@
+/**
+ * Real parser output for {@link SAMPLE_POEM_THREE_LINES} (same defaults as `parse_poem_wasm`: `uyir_u`).
+ * Regenerate after parser changes:
+ * `cd tamil-seiyul-alagi && cargo run --example dump_live_preview_fixture`
+ */
+import rawParseResult from '#/lib/__tests__/fixtures/samplePoemThreeLines.parseResult.json'
+
+import { adaptWasmJsonToParsedPoem } from '#/lib/adaptWasmParseJson'
+import { physicalPoemLines } from '#/lib/mapFeetToPhysicalLines'
+import type { ParsedPoem } from '#/types/parsedPoem'
+
+export const SAMPLE_POEM_THREE_LINES = rawParseResult.original_text as string
+
+/** Full `ParsedPoem` from the committed `ParseResult` JSON (via the same adapter as WASM). */
+export function parsedSampleThreeLines(): ParsedPoem {
+  const p = adaptWasmJsonToParsedPoem(rawParseResult)
+  if (!p) throw new Error('samplePoemThreeLines.parseResult.json failed adaptWasmJsonToParsedPoem')
+  return p
+}
+
+/**
+ * First two physical lines of the sample + matching `lines` slice — for layout-only tests
+ * without loading WASM.
+ */
+export function parsedSampleFirstTwoLines(): ParsedPoem {
+  const full = parsedSampleThreeLines()
+  const parts = full.original_text.replace(/\r\n/g, '\n').split('\n')
+  while (parts.length > 0 && parts[parts.length - 1] === '') {
+    parts.pop()
+  }
+  const two = parts.slice(0, 2)
+  const poemText = two.join('\n') + '\n'
+  const lines = full.lines.slice(0, 2)
+  return {
+    ...full,
+    original_text: poemText,
+    lines,
+  }
+}
+
+/** Sanity: editor line split matches fixture row count for the full sample. */
+export function assertSamplePhysicalLineCount(): void {
+  const full = parsedSampleThreeLines()
+  const n = physicalPoemLines(SAMPLE_POEM_THREE_LINES).length
+  if (n !== full.lines.length) {
+    throw new Error(
+      `Fixture out of sync: physicalPoemLines=${n} vs parsed.lines=${full.lines.length}. Regenerate with cargo run --example dump_live_preview_fixture`,
+    )
+  }
+}

--- a/src/lib/__tests__/fixtures/samplePoemThreeLines.parseResult.json
+++ b/src/lib/__tests__/fixtures/samplePoemThreeLines.parseResult.json
@@ -1,0 +1,3032 @@
+{
+  "original_text": "சுடர்த்தொடீஇ கேளாய் தெருவில்நாம்\nமணற்சிற்றில் காலில் சிதையா அடை\nகோதை பரிந்து வரிப்பந்து கொண்டோ\n",
+  "normalized_text": "சுடர்த்தொடீஇ கேளாய் தெருவில்நாம்\nமணற்சிற்றில் காலில் சிதையா அடை\nகோதை பரிந்து வரிப்பந்து கொண்டோ",
+  "letter_count": 56,
+  "vikalpa_count": 0,
+  "poem": {
+    "normalized_text": "சுடர்த்தொடீஇ கேளாய் தெருவில்நாம்\nமணற்சிற்றில் காலில் சிதையா அடை\nகோதை பரிந்து வரிப்பந்து கொண்டோ",
+    "lines": [
+      {
+        "line_index": 0,
+        "line_class": "—",
+        "linguistic_words": [
+          {
+            "word_index_in_line": 0,
+            "syllables": [
+              {
+                "inner": {
+                  "text": "சுடர்",
+                  "syllable_type": "Nirai",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai (triplet)",
+                  "line_index": 0,
+                  "word_index_in_line": 0
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "சு",
+                      "letter_type": "Uyirmei",
+                      "matra": 1
+                    }
+                  },
+                  {
+                    "inner": {
+                      "text": "ட",
+                      "letter_type": "Uyirmei",
+                      "matra": 1
+                    }
+                  },
+                  {
+                    "inner": {
+                      "text": "ர்",
+                      "letter_type": "Mei",
+                      "matra": 0
+                    }
+                  }
+                ],
+                "global_index": 0
+              },
+              {
+                "inner": {
+                  "text": "தொடீ",
+                  "syllable_type": "Nirai",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai/Ner (pair)",
+                  "line_index": 0,
+                  "word_index_in_line": 0
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "தொ",
+                      "letter_type": "Uyirmei",
+                      "matra": 1
+                    }
+                  },
+                  {
+                    "inner": {
+                      "text": "டீ",
+                      "letter_type": "Uyirmei",
+                      "matra": 2
+                    }
+                  }
+                ],
+                "global_index": 1
+              },
+              {
+                "inner": {
+                  "text": "இ",
+                  "syllable_type": "Ner",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai/Ner (pair)",
+                  "line_index": 0,
+                  "word_index_in_line": 0
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "இ",
+                      "letter_type": "Uyir",
+                      "matra": 1
+                    }
+                  }
+                ],
+                "global_index": 2
+              }
+            ]
+          },
+          {
+            "word_index_in_line": 1,
+            "syllables": [
+              {
+                "inner": {
+                  "text": "கே",
+                  "syllable_type": "Ner",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai/Ner (pair)",
+                  "line_index": 0,
+                  "word_index_in_line": 1
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "கே",
+                      "letter_type": "Uyirmei",
+                      "matra": 2
+                    }
+                  }
+                ],
+                "global_index": 3
+              },
+              {
+                "inner": {
+                  "text": "ளாய்",
+                  "syllable_type": "Ner",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai/Ner (pair)",
+                  "line_index": 0,
+                  "word_index_in_line": 1
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "ளா",
+                      "letter_type": "Uyirmei",
+                      "matra": 2
+                    }
+                  },
+                  {
+                    "inner": {
+                      "text": "ய்",
+                      "letter_type": "Mei",
+                      "matra": 0
+                    }
+                  }
+                ],
+                "global_index": 4
+              }
+            ]
+          },
+          {
+            "word_index_in_line": 2,
+            "syllables": [
+              {
+                "inner": {
+                  "text": "தெரு",
+                  "syllable_type": "Nirai",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai/Ner (pair)",
+                  "line_index": 0,
+                  "word_index_in_line": 2
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "தெ",
+                      "letter_type": "Uyirmei",
+                      "matra": 1
+                    }
+                  },
+                  {
+                    "inner": {
+                      "text": "ரு",
+                      "letter_type": "Uyirmei",
+                      "matra": 1
+                    }
+                  }
+                ],
+                "global_index": 5
+              },
+              {
+                "inner": {
+                  "text": "வில்",
+                  "syllable_type": "Ner",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai/Ner (pair)",
+                  "line_index": 0,
+                  "word_index_in_line": 2
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "வி",
+                      "letter_type": "Uyirmei",
+                      "matra": 1
+                    }
+                  },
+                  {
+                    "inner": {
+                      "text": "ல்",
+                      "letter_type": "Mei",
+                      "matra": 0
+                    }
+                  }
+                ],
+                "global_index": 6
+              },
+              {
+                "inner": {
+                  "text": "நாம்",
+                  "syllable_type": "Ner",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai/Ner (pair)",
+                  "line_index": 0,
+                  "word_index_in_line": 2
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "நா",
+                      "letter_type": "Uyirmei",
+                      "matra": 2
+                    }
+                  },
+                  {
+                    "inner": {
+                      "text": "ம்",
+                      "letter_type": "Mei",
+                      "matra": 0
+                    }
+                  }
+                ],
+                "global_index": 7
+              }
+            ]
+          }
+        ],
+        "words": [
+          {
+            "foot_type": "Nirai-Nirai-Ner",
+            "syllables": [
+              {
+                "inner": {
+                  "text": "சுடர்",
+                  "syllable_type": "Nirai",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai (triplet)",
+                  "line_index": 0,
+                  "word_index_in_line": 0
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "சு",
+                      "letter_type": "Uyirmei",
+                      "matra": 1
+                    }
+                  },
+                  {
+                    "inner": {
+                      "text": "ட",
+                      "letter_type": "Uyirmei",
+                      "matra": 1
+                    }
+                  },
+                  {
+                    "inner": {
+                      "text": "ர்",
+                      "letter_type": "Mei",
+                      "matra": 0
+                    }
+                  }
+                ],
+                "global_index": 0
+              },
+              {
+                "inner": {
+                  "text": "தொடீ",
+                  "syllable_type": "Nirai",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai/Ner (pair)",
+                  "line_index": 0,
+                  "word_index_in_line": 0
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "தொ",
+                      "letter_type": "Uyirmei",
+                      "matra": 1
+                    }
+                  },
+                  {
+                    "inner": {
+                      "text": "டீ",
+                      "letter_type": "Uyirmei",
+                      "matra": 2
+                    }
+                  }
+                ],
+                "global_index": 1
+              },
+              {
+                "inner": {
+                  "text": "இ",
+                  "syllable_type": "Ner",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai/Ner (pair)",
+                  "line_index": 0,
+                  "word_index_in_line": 0
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "இ",
+                      "letter_type": "Uyir",
+                      "matra": 1
+                    }
+                  }
+                ],
+                "global_index": 2
+              }
+            ],
+            "word_index_in_line": 0,
+            "foot_index_global": 0
+          },
+          {
+            "foot_type": "Ner-Ner",
+            "syllables": [
+              {
+                "inner": {
+                  "text": "கே",
+                  "syllable_type": "Ner",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai/Ner (pair)",
+                  "line_index": 0,
+                  "word_index_in_line": 1
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "கே",
+                      "letter_type": "Uyirmei",
+                      "matra": 2
+                    }
+                  }
+                ],
+                "global_index": 3
+              },
+              {
+                "inner": {
+                  "text": "ளாய்",
+                  "syllable_type": "Ner",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai/Ner (pair)",
+                  "line_index": 0,
+                  "word_index_in_line": 1
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "ளா",
+                      "letter_type": "Uyirmei",
+                      "matra": 2
+                    }
+                  },
+                  {
+                    "inner": {
+                      "text": "ய்",
+                      "letter_type": "Mei",
+                      "matra": 0
+                    }
+                  }
+                ],
+                "global_index": 4
+              }
+            ],
+            "word_index_in_line": 1,
+            "foot_index_global": 1
+          },
+          {
+            "foot_type": "Nirai-Ner-Ner",
+            "syllables": [
+              {
+                "inner": {
+                  "text": "தெரு",
+                  "syllable_type": "Nirai",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai/Ner (pair)",
+                  "line_index": 0,
+                  "word_index_in_line": 2
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "தெ",
+                      "letter_type": "Uyirmei",
+                      "matra": 1
+                    }
+                  },
+                  {
+                    "inner": {
+                      "text": "ரு",
+                      "letter_type": "Uyirmei",
+                      "matra": 1
+                    }
+                  }
+                ],
+                "global_index": 5
+              },
+              {
+                "inner": {
+                  "text": "வில்",
+                  "syllable_type": "Ner",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai/Ner (pair)",
+                  "line_index": 0,
+                  "word_index_in_line": 2
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "வி",
+                      "letter_type": "Uyirmei",
+                      "matra": 1
+                    }
+                  },
+                  {
+                    "inner": {
+                      "text": "ல்",
+                      "letter_type": "Mei",
+                      "matra": 0
+                    }
+                  }
+                ],
+                "global_index": 6
+              },
+              {
+                "inner": {
+                  "text": "நாம்",
+                  "syllable_type": "Ner",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai/Ner (pair)",
+                  "line_index": 0,
+                  "word_index_in_line": 2
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "நா",
+                      "letter_type": "Uyirmei",
+                      "matra": 2
+                    }
+                  },
+                  {
+                    "inner": {
+                      "text": "ம்",
+                      "letter_type": "Mei",
+                      "matra": 0
+                    }
+                  }
+                ],
+                "global_index": 7
+              }
+            ],
+            "word_index_in_line": 2,
+            "foot_index_global": 2
+          },
+          {
+            "foot_type": "Nirai-Ner-Ner",
+            "syllables": [
+              {
+                "inner": {
+                  "text": "மணற்",
+                  "syllable_type": "Nirai",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai (triplet)",
+                  "line_index": 1,
+                  "word_index_in_line": 0
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "ம",
+                      "letter_type": "Uyirmei",
+                      "matra": 1
+                    }
+                  },
+                  {
+                    "inner": {
+                      "text": "ண",
+                      "letter_type": "Uyirmei",
+                      "matra": 1
+                    }
+                  },
+                  {
+                    "inner": {
+                      "text": "ற்",
+                      "letter_type": "Mei",
+                      "matra": 0
+                    }
+                  }
+                ],
+                "global_index": 8
+              },
+              {
+                "inner": {
+                  "text": "சிற்",
+                  "syllable_type": "Ner",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai/Ner (pair)",
+                  "line_index": 1,
+                  "word_index_in_line": 0
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "சி",
+                      "letter_type": "Uyirmei",
+                      "matra": 1
+                    }
+                  },
+                  {
+                    "inner": {
+                      "text": "ற்",
+                      "letter_type": "Mei",
+                      "matra": 0
+                    }
+                  }
+                ],
+                "global_index": 9
+              },
+              {
+                "inner": {
+                  "text": "றில்",
+                  "syllable_type": "Ner",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai/Ner (pair)",
+                  "line_index": 1,
+                  "word_index_in_line": 0
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "றி",
+                      "letter_type": "Uyirmei",
+                      "matra": 1
+                    }
+                  },
+                  {
+                    "inner": {
+                      "text": "ல்",
+                      "letter_type": "Mei",
+                      "matra": 0
+                    }
+                  }
+                ],
+                "global_index": 10
+              }
+            ],
+            "word_index_in_line": 3,
+            "foot_index_global": 3
+          },
+          {
+            "foot_type": "Ner-Ner",
+            "syllables": [
+              {
+                "inner": {
+                  "text": "கா",
+                  "syllable_type": "Ner",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai/Ner (pair)",
+                  "line_index": 1,
+                  "word_index_in_line": 1
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "கா",
+                      "letter_type": "Uyirmei",
+                      "matra": 2
+                    }
+                  }
+                ],
+                "global_index": 11
+              },
+              {
+                "inner": {
+                  "text": "லில்",
+                  "syllable_type": "Ner",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai/Ner (pair)",
+                  "line_index": 1,
+                  "word_index_in_line": 1
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "லி",
+                      "letter_type": "Uyirmei",
+                      "matra": 1
+                    }
+                  },
+                  {
+                    "inner": {
+                      "text": "ல்",
+                      "letter_type": "Mei",
+                      "matra": 0
+                    }
+                  }
+                ],
+                "global_index": 12
+              }
+            ],
+            "word_index_in_line": 4,
+            "foot_index_global": 4
+          },
+          {
+            "foot_type": "Nirai-Ner",
+            "syllables": [
+              {
+                "inner": {
+                  "text": "சிதை",
+                  "syllable_type": "Nirai",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai/Ner (pair)",
+                  "line_index": 1,
+                  "word_index_in_line": 2
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "சி",
+                      "letter_type": "Uyirmei",
+                      "matra": 1
+                    }
+                  },
+                  {
+                    "inner": {
+                      "text": "தை",
+                      "letter_type": "Uyirmei",
+                      "matra": 2
+                    }
+                  }
+                ],
+                "global_index": 13
+              },
+              {
+                "inner": {
+                  "text": "யா",
+                  "syllable_type": "Ner",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai/Ner (pair)",
+                  "line_index": 1,
+                  "word_index_in_line": 2
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "யா",
+                      "letter_type": "Uyirmei",
+                      "matra": 2
+                    }
+                  }
+                ],
+                "global_index": 14
+              }
+            ],
+            "word_index_in_line": 5,
+            "foot_index_global": 5
+          },
+          {
+            "foot_type": "Nirai",
+            "syllables": [
+              {
+                "inner": {
+                  "text": "அடை",
+                  "syllable_type": "Nirai",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai/Ner (pair)",
+                  "line_index": 1,
+                  "word_index_in_line": 3
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "அ",
+                      "letter_type": "Uyir",
+                      "matra": 1
+                    }
+                  },
+                  {
+                    "inner": {
+                      "text": "டை",
+                      "letter_type": "Uyirmei",
+                      "matra": 2
+                    }
+                  }
+                ],
+                "global_index": 15
+              }
+            ],
+            "word_index_in_line": 6,
+            "foot_index_global": 6
+          },
+          {
+            "foot_type": "Ner-Ner",
+            "syllables": [
+              {
+                "inner": {
+                  "text": "கோ",
+                  "syllable_type": "Ner",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai/Ner (pair)",
+                  "line_index": 2,
+                  "word_index_in_line": 0
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "கோ",
+                      "letter_type": "Uyirmei",
+                      "matra": 2
+                    }
+                  }
+                ],
+                "global_index": 16
+              },
+              {
+                "inner": {
+                  "text": "தை",
+                  "syllable_type": "Ner",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai/Ner (pair)",
+                  "line_index": 2,
+                  "word_index_in_line": 0
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "தை",
+                      "letter_type": "Uyirmei",
+                      "matra": 2
+                    }
+                  }
+                ],
+                "global_index": 17
+              }
+            ],
+            "word_index_in_line": 7,
+            "foot_index_global": 7
+          },
+          {
+            "foot_type": "Nirai-Ner",
+            "syllables": [
+              {
+                "inner": {
+                  "text": "பரிந்",
+                  "syllable_type": "Nirai",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai (triplet)",
+                  "line_index": 2,
+                  "word_index_in_line": 1
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "ப",
+                      "letter_type": "Uyirmei",
+                      "matra": 1
+                    }
+                  },
+                  {
+                    "inner": {
+                      "text": "ரி",
+                      "letter_type": "Uyirmei",
+                      "matra": 1
+                    }
+                  },
+                  {
+                    "inner": {
+                      "text": "ந்",
+                      "letter_type": "Mei",
+                      "matra": 0
+                    }
+                  }
+                ],
+                "global_index": 18
+              },
+              {
+                "inner": {
+                  "text": "து",
+                  "syllable_type": "Ner",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai/Ner (pair)",
+                  "line_index": 2,
+                  "word_index_in_line": 1
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "து",
+                      "letter_type": "Uyirmei",
+                      "matra": 1
+                    }
+                  }
+                ],
+                "global_index": 19
+              }
+            ],
+            "word_index_in_line": 8,
+            "foot_index_global": 8
+          },
+          {
+            "foot_type": "Nirai-Ner-Ner",
+            "syllables": [
+              {
+                "inner": {
+                  "text": "வரிப்",
+                  "syllable_type": "Nirai",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai (triplet)",
+                  "line_index": 2,
+                  "word_index_in_line": 2
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "வ",
+                      "letter_type": "Uyirmei",
+                      "matra": 1
+                    }
+                  },
+                  {
+                    "inner": {
+                      "text": "ரி",
+                      "letter_type": "Uyirmei",
+                      "matra": 1
+                    }
+                  },
+                  {
+                    "inner": {
+                      "text": "ப்",
+                      "letter_type": "Mei",
+                      "matra": 0
+                    }
+                  }
+                ],
+                "global_index": 20
+              },
+              {
+                "inner": {
+                  "text": "பந்",
+                  "syllable_type": "Ner",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai/Ner (pair)",
+                  "line_index": 2,
+                  "word_index_in_line": 2
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "ப",
+                      "letter_type": "Uyirmei",
+                      "matra": 1
+                    }
+                  },
+                  {
+                    "inner": {
+                      "text": "ந்",
+                      "letter_type": "Mei",
+                      "matra": 0
+                    }
+                  }
+                ],
+                "global_index": 21
+              },
+              {
+                "inner": {
+                  "text": "து",
+                  "syllable_type": "Ner",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai/Ner (pair)",
+                  "line_index": 2,
+                  "word_index_in_line": 2
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "து",
+                      "letter_type": "Uyirmei",
+                      "matra": 1
+                    }
+                  }
+                ],
+                "global_index": 22
+              }
+            ],
+            "word_index_in_line": 9,
+            "foot_index_global": 9
+          },
+          {
+            "foot_type": "Ner-Ner",
+            "syllables": [
+              {
+                "inner": {
+                  "text": "கொண்",
+                  "syllable_type": "Ner",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai/Ner (pair)",
+                  "line_index": 2,
+                  "word_index_in_line": 3
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "கொ",
+                      "letter_type": "Uyirmei",
+                      "matra": 1
+                    }
+                  },
+                  {
+                    "inner": {
+                      "text": "ண்",
+                      "letter_type": "Mei",
+                      "matra": 0
+                    }
+                  }
+                ],
+                "global_index": 23
+              },
+              {
+                "inner": {
+                  "text": "டோ",
+                  "syllable_type": "Ner",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai/Ner (pair)",
+                  "line_index": 2,
+                  "word_index_in_line": 3
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "டோ",
+                      "letter_type": "Uyirmei",
+                      "matra": 2
+                    }
+                  }
+                ],
+                "global_index": 24
+              }
+            ],
+            "word_index_in_line": 10,
+            "foot_index_global": 10
+          }
+        ]
+      },
+      {
+        "line_index": 1,
+        "line_class": "—",
+        "linguistic_words": [
+          {
+            "word_index_in_line": 0,
+            "syllables": [
+              {
+                "inner": {
+                  "text": "மணற்",
+                  "syllable_type": "Nirai",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai (triplet)",
+                  "line_index": 1,
+                  "word_index_in_line": 0
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "ம",
+                      "letter_type": "Uyirmei",
+                      "matra": 1
+                    }
+                  },
+                  {
+                    "inner": {
+                      "text": "ண",
+                      "letter_type": "Uyirmei",
+                      "matra": 1
+                    }
+                  },
+                  {
+                    "inner": {
+                      "text": "ற்",
+                      "letter_type": "Mei",
+                      "matra": 0
+                    }
+                  }
+                ],
+                "global_index": 8
+              },
+              {
+                "inner": {
+                  "text": "சிற்",
+                  "syllable_type": "Ner",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai/Ner (pair)",
+                  "line_index": 1,
+                  "word_index_in_line": 0
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "சி",
+                      "letter_type": "Uyirmei",
+                      "matra": 1
+                    }
+                  },
+                  {
+                    "inner": {
+                      "text": "ற்",
+                      "letter_type": "Mei",
+                      "matra": 0
+                    }
+                  }
+                ],
+                "global_index": 9
+              },
+              {
+                "inner": {
+                  "text": "றில்",
+                  "syllable_type": "Ner",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai/Ner (pair)",
+                  "line_index": 1,
+                  "word_index_in_line": 0
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "றி",
+                      "letter_type": "Uyirmei",
+                      "matra": 1
+                    }
+                  },
+                  {
+                    "inner": {
+                      "text": "ல்",
+                      "letter_type": "Mei",
+                      "matra": 0
+                    }
+                  }
+                ],
+                "global_index": 10
+              }
+            ]
+          },
+          {
+            "word_index_in_line": 1,
+            "syllables": [
+              {
+                "inner": {
+                  "text": "கா",
+                  "syllable_type": "Ner",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai/Ner (pair)",
+                  "line_index": 1,
+                  "word_index_in_line": 1
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "கா",
+                      "letter_type": "Uyirmei",
+                      "matra": 2
+                    }
+                  }
+                ],
+                "global_index": 11
+              },
+              {
+                "inner": {
+                  "text": "லில்",
+                  "syllable_type": "Ner",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai/Ner (pair)",
+                  "line_index": 1,
+                  "word_index_in_line": 1
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "லி",
+                      "letter_type": "Uyirmei",
+                      "matra": 1
+                    }
+                  },
+                  {
+                    "inner": {
+                      "text": "ல்",
+                      "letter_type": "Mei",
+                      "matra": 0
+                    }
+                  }
+                ],
+                "global_index": 12
+              }
+            ]
+          },
+          {
+            "word_index_in_line": 2,
+            "syllables": [
+              {
+                "inner": {
+                  "text": "சிதை",
+                  "syllable_type": "Nirai",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai/Ner (pair)",
+                  "line_index": 1,
+                  "word_index_in_line": 2
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "சி",
+                      "letter_type": "Uyirmei",
+                      "matra": 1
+                    }
+                  },
+                  {
+                    "inner": {
+                      "text": "தை",
+                      "letter_type": "Uyirmei",
+                      "matra": 2
+                    }
+                  }
+                ],
+                "global_index": 13
+              },
+              {
+                "inner": {
+                  "text": "யா",
+                  "syllable_type": "Ner",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai/Ner (pair)",
+                  "line_index": 1,
+                  "word_index_in_line": 2
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "யா",
+                      "letter_type": "Uyirmei",
+                      "matra": 2
+                    }
+                  }
+                ],
+                "global_index": 14
+              }
+            ]
+          },
+          {
+            "word_index_in_line": 3,
+            "syllables": [
+              {
+                "inner": {
+                  "text": "அடை",
+                  "syllable_type": "Nirai",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai/Ner (pair)",
+                  "line_index": 1,
+                  "word_index_in_line": 3
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "அ",
+                      "letter_type": "Uyir",
+                      "matra": 1
+                    }
+                  },
+                  {
+                    "inner": {
+                      "text": "டை",
+                      "letter_type": "Uyirmei",
+                      "matra": 2
+                    }
+                  }
+                ],
+                "global_index": 15
+              }
+            ]
+          }
+        ],
+        "words": []
+      },
+      {
+        "line_index": 2,
+        "line_class": "—",
+        "linguistic_words": [
+          {
+            "word_index_in_line": 0,
+            "syllables": [
+              {
+                "inner": {
+                  "text": "கோ",
+                  "syllable_type": "Ner",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai/Ner (pair)",
+                  "line_index": 2,
+                  "word_index_in_line": 0
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "கோ",
+                      "letter_type": "Uyirmei",
+                      "matra": 2
+                    }
+                  }
+                ],
+                "global_index": 16
+              },
+              {
+                "inner": {
+                  "text": "தை",
+                  "syllable_type": "Ner",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai/Ner (pair)",
+                  "line_index": 2,
+                  "word_index_in_line": 0
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "தை",
+                      "letter_type": "Uyirmei",
+                      "matra": 2
+                    }
+                  }
+                ],
+                "global_index": 17
+              }
+            ]
+          },
+          {
+            "word_index_in_line": 1,
+            "syllables": [
+              {
+                "inner": {
+                  "text": "பரிந்",
+                  "syllable_type": "Nirai",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai (triplet)",
+                  "line_index": 2,
+                  "word_index_in_line": 1
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "ப",
+                      "letter_type": "Uyirmei",
+                      "matra": 1
+                    }
+                  },
+                  {
+                    "inner": {
+                      "text": "ரி",
+                      "letter_type": "Uyirmei",
+                      "matra": 1
+                    }
+                  },
+                  {
+                    "inner": {
+                      "text": "ந்",
+                      "letter_type": "Mei",
+                      "matra": 0
+                    }
+                  }
+                ],
+                "global_index": 18
+              },
+              {
+                "inner": {
+                  "text": "து",
+                  "syllable_type": "Ner",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai/Ner (pair)",
+                  "line_index": 2,
+                  "word_index_in_line": 1
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "து",
+                      "letter_type": "Uyirmei",
+                      "matra": 1
+                    }
+                  }
+                ],
+                "global_index": 19
+              }
+            ]
+          },
+          {
+            "word_index_in_line": 2,
+            "syllables": [
+              {
+                "inner": {
+                  "text": "வரிப்",
+                  "syllable_type": "Nirai",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai (triplet)",
+                  "line_index": 2,
+                  "word_index_in_line": 2
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "வ",
+                      "letter_type": "Uyirmei",
+                      "matra": 1
+                    }
+                  },
+                  {
+                    "inner": {
+                      "text": "ரி",
+                      "letter_type": "Uyirmei",
+                      "matra": 1
+                    }
+                  },
+                  {
+                    "inner": {
+                      "text": "ப்",
+                      "letter_type": "Mei",
+                      "matra": 0
+                    }
+                  }
+                ],
+                "global_index": 20
+              },
+              {
+                "inner": {
+                  "text": "பந்",
+                  "syllable_type": "Ner",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai/Ner (pair)",
+                  "line_index": 2,
+                  "word_index_in_line": 2
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "ப",
+                      "letter_type": "Uyirmei",
+                      "matra": 1
+                    }
+                  },
+                  {
+                    "inner": {
+                      "text": "ந்",
+                      "letter_type": "Mei",
+                      "matra": 0
+                    }
+                  }
+                ],
+                "global_index": 21
+              },
+              {
+                "inner": {
+                  "text": "து",
+                  "syllable_type": "Ner",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai/Ner (pair)",
+                  "line_index": 2,
+                  "word_index_in_line": 2
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "து",
+                      "letter_type": "Uyirmei",
+                      "matra": 1
+                    }
+                  }
+                ],
+                "global_index": 22
+              }
+            ]
+          },
+          {
+            "word_index_in_line": 3,
+            "syllables": [
+              {
+                "inner": {
+                  "text": "கொண்",
+                  "syllable_type": "Ner",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai/Ner (pair)",
+                  "line_index": 2,
+                  "word_index_in_line": 3
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "கொ",
+                      "letter_type": "Uyirmei",
+                      "matra": 1
+                    }
+                  },
+                  {
+                    "inner": {
+                      "text": "ண்",
+                      "letter_type": "Mei",
+                      "matra": 0
+                    }
+                  }
+                ],
+                "global_index": 23
+              },
+              {
+                "inner": {
+                  "text": "டோ",
+                  "syllable_type": "Ner",
+                  "split_hint": null,
+                  "alt_split": false,
+                  "rule_ref": "Nirai/Ner (pair)",
+                  "line_index": 2,
+                  "word_index_in_line": 3
+                },
+                "letters": [
+                  {
+                    "inner": {
+                      "text": "டோ",
+                      "letter_type": "Uyirmei",
+                      "matra": 2
+                    }
+                  }
+                ],
+                "global_index": 24
+              }
+            ]
+          }
+        ],
+        "words": []
+      }
+    ],
+    "syllables_flat": [
+      {
+        "text": "சுடர்",
+        "syllable_type": "Nirai",
+        "split_hint": null,
+        "alt_split": false,
+        "rule_ref": "Nirai (triplet)",
+        "line_index": 0,
+        "word_index_in_line": 0
+      },
+      {
+        "text": "தொடீ",
+        "syllable_type": "Nirai",
+        "split_hint": null,
+        "alt_split": false,
+        "rule_ref": "Nirai/Ner (pair)",
+        "line_index": 0,
+        "word_index_in_line": 0
+      },
+      {
+        "text": "இ",
+        "syllable_type": "Ner",
+        "split_hint": null,
+        "alt_split": false,
+        "rule_ref": "Nirai/Ner (pair)",
+        "line_index": 0,
+        "word_index_in_line": 0
+      },
+      {
+        "text": "கே",
+        "syllable_type": "Ner",
+        "split_hint": null,
+        "alt_split": false,
+        "rule_ref": "Nirai/Ner (pair)",
+        "line_index": 0,
+        "word_index_in_line": 1
+      },
+      {
+        "text": "ளாய்",
+        "syllable_type": "Ner",
+        "split_hint": null,
+        "alt_split": false,
+        "rule_ref": "Nirai/Ner (pair)",
+        "line_index": 0,
+        "word_index_in_line": 1
+      },
+      {
+        "text": "தெரு",
+        "syllable_type": "Nirai",
+        "split_hint": null,
+        "alt_split": false,
+        "rule_ref": "Nirai/Ner (pair)",
+        "line_index": 0,
+        "word_index_in_line": 2
+      },
+      {
+        "text": "வில்",
+        "syllable_type": "Ner",
+        "split_hint": null,
+        "alt_split": false,
+        "rule_ref": "Nirai/Ner (pair)",
+        "line_index": 0,
+        "word_index_in_line": 2
+      },
+      {
+        "text": "நாம்",
+        "syllable_type": "Ner",
+        "split_hint": null,
+        "alt_split": false,
+        "rule_ref": "Nirai/Ner (pair)",
+        "line_index": 0,
+        "word_index_in_line": 2
+      },
+      {
+        "text": "மணற்",
+        "syllable_type": "Nirai",
+        "split_hint": null,
+        "alt_split": false,
+        "rule_ref": "Nirai (triplet)",
+        "line_index": 1,
+        "word_index_in_line": 0
+      },
+      {
+        "text": "சிற்",
+        "syllable_type": "Ner",
+        "split_hint": null,
+        "alt_split": false,
+        "rule_ref": "Nirai/Ner (pair)",
+        "line_index": 1,
+        "word_index_in_line": 0
+      },
+      {
+        "text": "றில்",
+        "syllable_type": "Ner",
+        "split_hint": null,
+        "alt_split": false,
+        "rule_ref": "Nirai/Ner (pair)",
+        "line_index": 1,
+        "word_index_in_line": 0
+      },
+      {
+        "text": "கா",
+        "syllable_type": "Ner",
+        "split_hint": null,
+        "alt_split": false,
+        "rule_ref": "Nirai/Ner (pair)",
+        "line_index": 1,
+        "word_index_in_line": 1
+      },
+      {
+        "text": "லில்",
+        "syllable_type": "Ner",
+        "split_hint": null,
+        "alt_split": false,
+        "rule_ref": "Nirai/Ner (pair)",
+        "line_index": 1,
+        "word_index_in_line": 1
+      },
+      {
+        "text": "சிதை",
+        "syllable_type": "Nirai",
+        "split_hint": null,
+        "alt_split": false,
+        "rule_ref": "Nirai/Ner (pair)",
+        "line_index": 1,
+        "word_index_in_line": 2
+      },
+      {
+        "text": "யா",
+        "syllable_type": "Ner",
+        "split_hint": null,
+        "alt_split": false,
+        "rule_ref": "Nirai/Ner (pair)",
+        "line_index": 1,
+        "word_index_in_line": 2
+      },
+      {
+        "text": "அடை",
+        "syllable_type": "Nirai",
+        "split_hint": null,
+        "alt_split": false,
+        "rule_ref": "Nirai/Ner (pair)",
+        "line_index": 1,
+        "word_index_in_line": 3
+      },
+      {
+        "text": "கோ",
+        "syllable_type": "Ner",
+        "split_hint": null,
+        "alt_split": false,
+        "rule_ref": "Nirai/Ner (pair)",
+        "line_index": 2,
+        "word_index_in_line": 0
+      },
+      {
+        "text": "தை",
+        "syllable_type": "Ner",
+        "split_hint": null,
+        "alt_split": false,
+        "rule_ref": "Nirai/Ner (pair)",
+        "line_index": 2,
+        "word_index_in_line": 0
+      },
+      {
+        "text": "பரிந்",
+        "syllable_type": "Nirai",
+        "split_hint": null,
+        "alt_split": false,
+        "rule_ref": "Nirai (triplet)",
+        "line_index": 2,
+        "word_index_in_line": 1
+      },
+      {
+        "text": "து",
+        "syllable_type": "Ner",
+        "split_hint": null,
+        "alt_split": false,
+        "rule_ref": "Nirai/Ner (pair)",
+        "line_index": 2,
+        "word_index_in_line": 1
+      },
+      {
+        "text": "வரிப்",
+        "syllable_type": "Nirai",
+        "split_hint": null,
+        "alt_split": false,
+        "rule_ref": "Nirai (triplet)",
+        "line_index": 2,
+        "word_index_in_line": 2
+      },
+      {
+        "text": "பந்",
+        "syllable_type": "Ner",
+        "split_hint": null,
+        "alt_split": false,
+        "rule_ref": "Nirai/Ner (pair)",
+        "line_index": 2,
+        "word_index_in_line": 2
+      },
+      {
+        "text": "து",
+        "syllable_type": "Ner",
+        "split_hint": null,
+        "alt_split": false,
+        "rule_ref": "Nirai/Ner (pair)",
+        "line_index": 2,
+        "word_index_in_line": 2
+      },
+      {
+        "text": "கொண்",
+        "syllable_type": "Ner",
+        "split_hint": null,
+        "alt_split": false,
+        "rule_ref": "Nirai/Ner (pair)",
+        "line_index": 2,
+        "word_index_in_line": 3
+      },
+      {
+        "text": "டோ",
+        "syllable_type": "Ner",
+        "split_hint": null,
+        "alt_split": false,
+        "rule_ref": "Nirai/Ner (pair)",
+        "line_index": 2,
+        "word_index_in_line": 3
+      }
+    ],
+    "linkage": [
+      {
+        "from_foot": 0,
+        "to_foot": 1,
+        "from": {
+          "foot_index": 0,
+          "line_index": 0,
+          "word_index_in_line": 0
+        },
+        "to": {
+          "foot_index": 1,
+          "line_index": 0,
+          "word_index_in_line": 1
+        },
+        "linkage_type": "VenTalai",
+        "is_valid": true
+      },
+      {
+        "from_foot": 1,
+        "to_foot": 2,
+        "from": {
+          "foot_index": 1,
+          "line_index": 0,
+          "word_index_in_line": 1
+        },
+        "to": {
+          "foot_index": 2,
+          "line_index": 0,
+          "word_index_in_line": 2
+        },
+        "linkage_type": "VenTalai",
+        "is_valid": true
+      },
+      {
+        "from_foot": 2,
+        "to_foot": 3,
+        "from": {
+          "foot_index": 2,
+          "line_index": 0,
+          "word_index_in_line": 2
+        },
+        "to": {
+          "foot_index": 3,
+          "line_index": 0,
+          "word_index_in_line": 3
+        },
+        "linkage_type": "VenTalai",
+        "is_valid": true
+      },
+      {
+        "from_foot": 3,
+        "to_foot": 4,
+        "from": {
+          "foot_index": 3,
+          "line_index": 0,
+          "word_index_in_line": 3
+        },
+        "to": {
+          "foot_index": 4,
+          "line_index": 0,
+          "word_index_in_line": 4
+        },
+        "linkage_type": "VenTalai",
+        "is_valid": true
+      },
+      {
+        "from_foot": 4,
+        "to_foot": 5,
+        "from": {
+          "foot_index": 4,
+          "line_index": 0,
+          "word_index_in_line": 4
+        },
+        "to": {
+          "foot_index": 5,
+          "line_index": 0,
+          "word_index_in_line": 5
+        },
+        "linkage_type": "VenTalai",
+        "is_valid": true
+      },
+      {
+        "from_foot": 5,
+        "to_foot": 6,
+        "from": {
+          "foot_index": 5,
+          "line_index": 0,
+          "word_index_in_line": 5
+        },
+        "to": {
+          "foot_index": 6,
+          "line_index": 0,
+          "word_index_in_line": 6
+        },
+        "linkage_type": "VenTalai",
+        "is_valid": true
+      },
+      {
+        "from_foot": 6,
+        "to_foot": 7,
+        "from": {
+          "foot_index": 6,
+          "line_index": 0,
+          "word_index_in_line": 6
+        },
+        "to": {
+          "foot_index": 7,
+          "line_index": 0,
+          "word_index_in_line": 7
+        },
+        "linkage_type": "VenTalai",
+        "is_valid": true
+      },
+      {
+        "from_foot": 7,
+        "to_foot": 8,
+        "from": {
+          "foot_index": 7,
+          "line_index": 0,
+          "word_index_in_line": 7
+        },
+        "to": {
+          "foot_index": 8,
+          "line_index": 0,
+          "word_index_in_line": 8
+        },
+        "linkage_type": "VenTalai",
+        "is_valid": true
+      },
+      {
+        "from_foot": 8,
+        "to_foot": 9,
+        "from": {
+          "foot_index": 8,
+          "line_index": 0,
+          "word_index_in_line": 8
+        },
+        "to": {
+          "foot_index": 9,
+          "line_index": 0,
+          "word_index_in_line": 9
+        },
+        "linkage_type": "VenTalai",
+        "is_valid": true
+      },
+      {
+        "from_foot": 9,
+        "to_foot": 10,
+        "from": {
+          "foot_index": 9,
+          "line_index": 0,
+          "word_index_in_line": 9
+        },
+        "to": {
+          "foot_index": 10,
+          "line_index": 0,
+          "word_index_in_line": 10
+        },
+        "linkage_type": "VenTalai",
+        "is_valid": true
+      }
+    ]
+  },
+  "syllables": [
+    {
+      "text": "சுடர்",
+      "syllable_type": "Nirai",
+      "split_hint": null,
+      "alt_split": false,
+      "rule_ref": "Nirai (triplet)",
+      "line_index": 0,
+      "word_index_in_line": 0
+    },
+    {
+      "text": "தொடீ",
+      "syllable_type": "Nirai",
+      "split_hint": null,
+      "alt_split": false,
+      "rule_ref": "Nirai/Ner (pair)",
+      "line_index": 0,
+      "word_index_in_line": 0
+    },
+    {
+      "text": "இ",
+      "syllable_type": "Ner",
+      "split_hint": null,
+      "alt_split": false,
+      "rule_ref": "Nirai/Ner (pair)",
+      "line_index": 0,
+      "word_index_in_line": 0
+    },
+    {
+      "text": "கே",
+      "syllable_type": "Ner",
+      "split_hint": null,
+      "alt_split": false,
+      "rule_ref": "Nirai/Ner (pair)",
+      "line_index": 0,
+      "word_index_in_line": 1
+    },
+    {
+      "text": "ளாய்",
+      "syllable_type": "Ner",
+      "split_hint": null,
+      "alt_split": false,
+      "rule_ref": "Nirai/Ner (pair)",
+      "line_index": 0,
+      "word_index_in_line": 1
+    },
+    {
+      "text": "தெரு",
+      "syllable_type": "Nirai",
+      "split_hint": null,
+      "alt_split": false,
+      "rule_ref": "Nirai/Ner (pair)",
+      "line_index": 0,
+      "word_index_in_line": 2
+    },
+    {
+      "text": "வில்",
+      "syllable_type": "Ner",
+      "split_hint": null,
+      "alt_split": false,
+      "rule_ref": "Nirai/Ner (pair)",
+      "line_index": 0,
+      "word_index_in_line": 2
+    },
+    {
+      "text": "நாம்",
+      "syllable_type": "Ner",
+      "split_hint": null,
+      "alt_split": false,
+      "rule_ref": "Nirai/Ner (pair)",
+      "line_index": 0,
+      "word_index_in_line": 2
+    },
+    {
+      "text": "மணற்",
+      "syllable_type": "Nirai",
+      "split_hint": null,
+      "alt_split": false,
+      "rule_ref": "Nirai (triplet)",
+      "line_index": 1,
+      "word_index_in_line": 0
+    },
+    {
+      "text": "சிற்",
+      "syllable_type": "Ner",
+      "split_hint": null,
+      "alt_split": false,
+      "rule_ref": "Nirai/Ner (pair)",
+      "line_index": 1,
+      "word_index_in_line": 0
+    },
+    {
+      "text": "றில்",
+      "syllable_type": "Ner",
+      "split_hint": null,
+      "alt_split": false,
+      "rule_ref": "Nirai/Ner (pair)",
+      "line_index": 1,
+      "word_index_in_line": 0
+    },
+    {
+      "text": "கா",
+      "syllable_type": "Ner",
+      "split_hint": null,
+      "alt_split": false,
+      "rule_ref": "Nirai/Ner (pair)",
+      "line_index": 1,
+      "word_index_in_line": 1
+    },
+    {
+      "text": "லில்",
+      "syllable_type": "Ner",
+      "split_hint": null,
+      "alt_split": false,
+      "rule_ref": "Nirai/Ner (pair)",
+      "line_index": 1,
+      "word_index_in_line": 1
+    },
+    {
+      "text": "சிதை",
+      "syllable_type": "Nirai",
+      "split_hint": null,
+      "alt_split": false,
+      "rule_ref": "Nirai/Ner (pair)",
+      "line_index": 1,
+      "word_index_in_line": 2
+    },
+    {
+      "text": "யா",
+      "syllable_type": "Ner",
+      "split_hint": null,
+      "alt_split": false,
+      "rule_ref": "Nirai/Ner (pair)",
+      "line_index": 1,
+      "word_index_in_line": 2
+    },
+    {
+      "text": "அடை",
+      "syllable_type": "Nirai",
+      "split_hint": null,
+      "alt_split": false,
+      "rule_ref": "Nirai/Ner (pair)",
+      "line_index": 1,
+      "word_index_in_line": 3
+    },
+    {
+      "text": "கோ",
+      "syllable_type": "Ner",
+      "split_hint": null,
+      "alt_split": false,
+      "rule_ref": "Nirai/Ner (pair)",
+      "line_index": 2,
+      "word_index_in_line": 0
+    },
+    {
+      "text": "தை",
+      "syllable_type": "Ner",
+      "split_hint": null,
+      "alt_split": false,
+      "rule_ref": "Nirai/Ner (pair)",
+      "line_index": 2,
+      "word_index_in_line": 0
+    },
+    {
+      "text": "பரிந்",
+      "syllable_type": "Nirai",
+      "split_hint": null,
+      "alt_split": false,
+      "rule_ref": "Nirai (triplet)",
+      "line_index": 2,
+      "word_index_in_line": 1
+    },
+    {
+      "text": "து",
+      "syllable_type": "Ner",
+      "split_hint": null,
+      "alt_split": false,
+      "rule_ref": "Nirai/Ner (pair)",
+      "line_index": 2,
+      "word_index_in_line": 1
+    },
+    {
+      "text": "வரிப்",
+      "syllable_type": "Nirai",
+      "split_hint": null,
+      "alt_split": false,
+      "rule_ref": "Nirai (triplet)",
+      "line_index": 2,
+      "word_index_in_line": 2
+    },
+    {
+      "text": "பந்",
+      "syllable_type": "Ner",
+      "split_hint": null,
+      "alt_split": false,
+      "rule_ref": "Nirai/Ner (pair)",
+      "line_index": 2,
+      "word_index_in_line": 2
+    },
+    {
+      "text": "து",
+      "syllable_type": "Ner",
+      "split_hint": null,
+      "alt_split": false,
+      "rule_ref": "Nirai/Ner (pair)",
+      "line_index": 2,
+      "word_index_in_line": 2
+    },
+    {
+      "text": "கொண்",
+      "syllable_type": "Ner",
+      "split_hint": null,
+      "alt_split": false,
+      "rule_ref": "Nirai/Ner (pair)",
+      "line_index": 2,
+      "word_index_in_line": 3
+    },
+    {
+      "text": "டோ",
+      "syllable_type": "Ner",
+      "split_hint": null,
+      "alt_split": false,
+      "rule_ref": "Nirai/Ner (pair)",
+      "line_index": 2,
+      "word_index_in_line": 3
+    }
+  ],
+  "feet": [
+    {
+      "syllables": [
+        {
+          "text": "சுடர்",
+          "syllable_type": "Nirai",
+          "split_hint": null,
+          "alt_split": false,
+          "rule_ref": "Nirai (triplet)",
+          "line_index": 0,
+          "word_index_in_line": 0
+        },
+        {
+          "text": "தொடீ",
+          "syllable_type": "Nirai",
+          "split_hint": null,
+          "alt_split": false,
+          "rule_ref": "Nirai/Ner (pair)",
+          "line_index": 0,
+          "word_index_in_line": 0
+        },
+        {
+          "text": "இ",
+          "syllable_type": "Ner",
+          "split_hint": null,
+          "alt_split": false,
+          "rule_ref": "Nirai/Ner (pair)",
+          "line_index": 0,
+          "word_index_in_line": 0
+        }
+      ],
+      "foot_type": "Nirai-Nirai-Ner"
+    },
+    {
+      "syllables": [
+        {
+          "text": "கே",
+          "syllable_type": "Ner",
+          "split_hint": null,
+          "alt_split": false,
+          "rule_ref": "Nirai/Ner (pair)",
+          "line_index": 0,
+          "word_index_in_line": 1
+        },
+        {
+          "text": "ளாய்",
+          "syllable_type": "Ner",
+          "split_hint": null,
+          "alt_split": false,
+          "rule_ref": "Nirai/Ner (pair)",
+          "line_index": 0,
+          "word_index_in_line": 1
+        }
+      ],
+      "foot_type": "Ner-Ner"
+    },
+    {
+      "syllables": [
+        {
+          "text": "தெரு",
+          "syllable_type": "Nirai",
+          "split_hint": null,
+          "alt_split": false,
+          "rule_ref": "Nirai/Ner (pair)",
+          "line_index": 0,
+          "word_index_in_line": 2
+        },
+        {
+          "text": "வில்",
+          "syllable_type": "Ner",
+          "split_hint": null,
+          "alt_split": false,
+          "rule_ref": "Nirai/Ner (pair)",
+          "line_index": 0,
+          "word_index_in_line": 2
+        },
+        {
+          "text": "நாம்",
+          "syllable_type": "Ner",
+          "split_hint": null,
+          "alt_split": false,
+          "rule_ref": "Nirai/Ner (pair)",
+          "line_index": 0,
+          "word_index_in_line": 2
+        }
+      ],
+      "foot_type": "Nirai-Ner-Ner"
+    },
+    {
+      "syllables": [
+        {
+          "text": "மணற்",
+          "syllable_type": "Nirai",
+          "split_hint": null,
+          "alt_split": false,
+          "rule_ref": "Nirai (triplet)",
+          "line_index": 1,
+          "word_index_in_line": 0
+        },
+        {
+          "text": "சிற்",
+          "syllable_type": "Ner",
+          "split_hint": null,
+          "alt_split": false,
+          "rule_ref": "Nirai/Ner (pair)",
+          "line_index": 1,
+          "word_index_in_line": 0
+        },
+        {
+          "text": "றில்",
+          "syllable_type": "Ner",
+          "split_hint": null,
+          "alt_split": false,
+          "rule_ref": "Nirai/Ner (pair)",
+          "line_index": 1,
+          "word_index_in_line": 0
+        }
+      ],
+      "foot_type": "Nirai-Ner-Ner"
+    },
+    {
+      "syllables": [
+        {
+          "text": "கா",
+          "syllable_type": "Ner",
+          "split_hint": null,
+          "alt_split": false,
+          "rule_ref": "Nirai/Ner (pair)",
+          "line_index": 1,
+          "word_index_in_line": 1
+        },
+        {
+          "text": "லில்",
+          "syllable_type": "Ner",
+          "split_hint": null,
+          "alt_split": false,
+          "rule_ref": "Nirai/Ner (pair)",
+          "line_index": 1,
+          "word_index_in_line": 1
+        }
+      ],
+      "foot_type": "Ner-Ner"
+    },
+    {
+      "syllables": [
+        {
+          "text": "சிதை",
+          "syllable_type": "Nirai",
+          "split_hint": null,
+          "alt_split": false,
+          "rule_ref": "Nirai/Ner (pair)",
+          "line_index": 1,
+          "word_index_in_line": 2
+        },
+        {
+          "text": "யா",
+          "syllable_type": "Ner",
+          "split_hint": null,
+          "alt_split": false,
+          "rule_ref": "Nirai/Ner (pair)",
+          "line_index": 1,
+          "word_index_in_line": 2
+        }
+      ],
+      "foot_type": "Nirai-Ner"
+    },
+    {
+      "syllables": [
+        {
+          "text": "அடை",
+          "syllable_type": "Nirai",
+          "split_hint": null,
+          "alt_split": false,
+          "rule_ref": "Nirai/Ner (pair)",
+          "line_index": 1,
+          "word_index_in_line": 3
+        }
+      ],
+      "foot_type": "Nirai"
+    },
+    {
+      "syllables": [
+        {
+          "text": "கோ",
+          "syllable_type": "Ner",
+          "split_hint": null,
+          "alt_split": false,
+          "rule_ref": "Nirai/Ner (pair)",
+          "line_index": 2,
+          "word_index_in_line": 0
+        },
+        {
+          "text": "தை",
+          "syllable_type": "Ner",
+          "split_hint": null,
+          "alt_split": false,
+          "rule_ref": "Nirai/Ner (pair)",
+          "line_index": 2,
+          "word_index_in_line": 0
+        }
+      ],
+      "foot_type": "Ner-Ner"
+    },
+    {
+      "syllables": [
+        {
+          "text": "பரிந்",
+          "syllable_type": "Nirai",
+          "split_hint": null,
+          "alt_split": false,
+          "rule_ref": "Nirai (triplet)",
+          "line_index": 2,
+          "word_index_in_line": 1
+        },
+        {
+          "text": "து",
+          "syllable_type": "Ner",
+          "split_hint": null,
+          "alt_split": false,
+          "rule_ref": "Nirai/Ner (pair)",
+          "line_index": 2,
+          "word_index_in_line": 1
+        }
+      ],
+      "foot_type": "Nirai-Ner"
+    },
+    {
+      "syllables": [
+        {
+          "text": "வரிப்",
+          "syllable_type": "Nirai",
+          "split_hint": null,
+          "alt_split": false,
+          "rule_ref": "Nirai (triplet)",
+          "line_index": 2,
+          "word_index_in_line": 2
+        },
+        {
+          "text": "பந்",
+          "syllable_type": "Ner",
+          "split_hint": null,
+          "alt_split": false,
+          "rule_ref": "Nirai/Ner (pair)",
+          "line_index": 2,
+          "word_index_in_line": 2
+        },
+        {
+          "text": "து",
+          "syllable_type": "Ner",
+          "split_hint": null,
+          "alt_split": false,
+          "rule_ref": "Nirai/Ner (pair)",
+          "line_index": 2,
+          "word_index_in_line": 2
+        }
+      ],
+      "foot_type": "Nirai-Ner-Ner"
+    },
+    {
+      "syllables": [
+        {
+          "text": "கொண்",
+          "syllable_type": "Ner",
+          "split_hint": null,
+          "alt_split": false,
+          "rule_ref": "Nirai/Ner (pair)",
+          "line_index": 2,
+          "word_index_in_line": 3
+        },
+        {
+          "text": "டோ",
+          "syllable_type": "Ner",
+          "split_hint": null,
+          "alt_split": false,
+          "rule_ref": "Nirai/Ner (pair)",
+          "line_index": 2,
+          "word_index_in_line": 3
+        }
+      ],
+      "foot_type": "Ner-Ner"
+    }
+  ],
+  "linkage": [
+    {
+      "from_foot": 0,
+      "to_foot": 1,
+      "from": {
+        "foot_index": 0,
+        "line_index": 0,
+        "word_index_in_line": 0
+      },
+      "to": {
+        "foot_index": 1,
+        "line_index": 0,
+        "word_index_in_line": 1
+      },
+      "linkage_type": "VenTalai",
+      "is_valid": true
+    },
+    {
+      "from_foot": 1,
+      "to_foot": 2,
+      "from": {
+        "foot_index": 1,
+        "line_index": 0,
+        "word_index_in_line": 1
+      },
+      "to": {
+        "foot_index": 2,
+        "line_index": 0,
+        "word_index_in_line": 2
+      },
+      "linkage_type": "VenTalai",
+      "is_valid": true
+    },
+    {
+      "from_foot": 2,
+      "to_foot": 3,
+      "from": {
+        "foot_index": 2,
+        "line_index": 0,
+        "word_index_in_line": 2
+      },
+      "to": {
+        "foot_index": 3,
+        "line_index": 0,
+        "word_index_in_line": 3
+      },
+      "linkage_type": "VenTalai",
+      "is_valid": true
+    },
+    {
+      "from_foot": 3,
+      "to_foot": 4,
+      "from": {
+        "foot_index": 3,
+        "line_index": 0,
+        "word_index_in_line": 3
+      },
+      "to": {
+        "foot_index": 4,
+        "line_index": 0,
+        "word_index_in_line": 4
+      },
+      "linkage_type": "VenTalai",
+      "is_valid": true
+    },
+    {
+      "from_foot": 4,
+      "to_foot": 5,
+      "from": {
+        "foot_index": 4,
+        "line_index": 0,
+        "word_index_in_line": 4
+      },
+      "to": {
+        "foot_index": 5,
+        "line_index": 0,
+        "word_index_in_line": 5
+      },
+      "linkage_type": "VenTalai",
+      "is_valid": true
+    },
+    {
+      "from_foot": 5,
+      "to_foot": 6,
+      "from": {
+        "foot_index": 5,
+        "line_index": 0,
+        "word_index_in_line": 5
+      },
+      "to": {
+        "foot_index": 6,
+        "line_index": 0,
+        "word_index_in_line": 6
+      },
+      "linkage_type": "VenTalai",
+      "is_valid": true
+    },
+    {
+      "from_foot": 6,
+      "to_foot": 7,
+      "from": {
+        "foot_index": 6,
+        "line_index": 0,
+        "word_index_in_line": 6
+      },
+      "to": {
+        "foot_index": 7,
+        "line_index": 0,
+        "word_index_in_line": 7
+      },
+      "linkage_type": "VenTalai",
+      "is_valid": true
+    },
+    {
+      "from_foot": 7,
+      "to_foot": 8,
+      "from": {
+        "foot_index": 7,
+        "line_index": 0,
+        "word_index_in_line": 7
+      },
+      "to": {
+        "foot_index": 8,
+        "line_index": 0,
+        "word_index_in_line": 8
+      },
+      "linkage_type": "VenTalai",
+      "is_valid": true
+    },
+    {
+      "from_foot": 8,
+      "to_foot": 9,
+      "from": {
+        "foot_index": 8,
+        "line_index": 0,
+        "word_index_in_line": 8
+      },
+      "to": {
+        "foot_index": 9,
+        "line_index": 0,
+        "word_index_in_line": 9
+      },
+      "linkage_type": "VenTalai",
+      "is_valid": true
+    },
+    {
+      "from_foot": 9,
+      "to_foot": 10,
+      "from": {
+        "foot_index": 9,
+        "line_index": 0,
+        "word_index_in_line": 9
+      },
+      "to": {
+        "foot_index": 10,
+        "line_index": 0,
+        "word_index_in_line": 10
+      },
+      "linkage_type": "VenTalai",
+      "is_valid": true
+    }
+  ],
+  "talai": [
+    {
+      "from_foot": 0,
+      "to_foot": 1,
+      "from": {
+        "foot_index": 0,
+        "line_index": 0,
+        "word_index_in_line": 0
+      },
+      "to": {
+        "foot_index": 1,
+        "line_index": 0,
+        "word_index_in_line": 1
+      },
+      "linkage_type": "VenTalai",
+      "is_valid": true
+    },
+    {
+      "from_foot": 1,
+      "to_foot": 2,
+      "from": {
+        "foot_index": 1,
+        "line_index": 0,
+        "word_index_in_line": 1
+      },
+      "to": {
+        "foot_index": 2,
+        "line_index": 0,
+        "word_index_in_line": 2
+      },
+      "linkage_type": "VenTalai",
+      "is_valid": true
+    },
+    {
+      "from_foot": 2,
+      "to_foot": 3,
+      "from": {
+        "foot_index": 2,
+        "line_index": 0,
+        "word_index_in_line": 2
+      },
+      "to": {
+        "foot_index": 3,
+        "line_index": 0,
+        "word_index_in_line": 3
+      },
+      "linkage_type": "VenTalai",
+      "is_valid": true
+    },
+    {
+      "from_foot": 3,
+      "to_foot": 4,
+      "from": {
+        "foot_index": 3,
+        "line_index": 0,
+        "word_index_in_line": 3
+      },
+      "to": {
+        "foot_index": 4,
+        "line_index": 0,
+        "word_index_in_line": 4
+      },
+      "linkage_type": "VenTalai",
+      "is_valid": true
+    },
+    {
+      "from_foot": 4,
+      "to_foot": 5,
+      "from": {
+        "foot_index": 4,
+        "line_index": 0,
+        "word_index_in_line": 4
+      },
+      "to": {
+        "foot_index": 5,
+        "line_index": 0,
+        "word_index_in_line": 5
+      },
+      "linkage_type": "VenTalai",
+      "is_valid": true
+    },
+    {
+      "from_foot": 5,
+      "to_foot": 6,
+      "from": {
+        "foot_index": 5,
+        "line_index": 0,
+        "word_index_in_line": 5
+      },
+      "to": {
+        "foot_index": 6,
+        "line_index": 0,
+        "word_index_in_line": 6
+      },
+      "linkage_type": "VenTalai",
+      "is_valid": true
+    },
+    {
+      "from_foot": 6,
+      "to_foot": 7,
+      "from": {
+        "foot_index": 6,
+        "line_index": 0,
+        "word_index_in_line": 6
+      },
+      "to": {
+        "foot_index": 7,
+        "line_index": 0,
+        "word_index_in_line": 7
+      },
+      "linkage_type": "VenTalai",
+      "is_valid": true
+    },
+    {
+      "from_foot": 7,
+      "to_foot": 8,
+      "from": {
+        "foot_index": 7,
+        "line_index": 0,
+        "word_index_in_line": 7
+      },
+      "to": {
+        "foot_index": 8,
+        "line_index": 0,
+        "word_index_in_line": 8
+      },
+      "linkage_type": "VenTalai",
+      "is_valid": true
+    },
+    {
+      "from_foot": 8,
+      "to_foot": 9,
+      "from": {
+        "foot_index": 8,
+        "line_index": 0,
+        "word_index_in_line": 8
+      },
+      "to": {
+        "foot_index": 9,
+        "line_index": 0,
+        "word_index_in_line": 9
+      },
+      "linkage_type": "VenTalai",
+      "is_valid": true
+    },
+    {
+      "from_foot": 9,
+      "to_foot": 10,
+      "from": {
+        "foot_index": 9,
+        "line_index": 0,
+        "word_index_in_line": 9
+      },
+      "to": {
+        "foot_index": 10,
+        "line_index": 0,
+        "word_index_in_line": 10
+      },
+      "linkage_type": "VenTalai",
+      "is_valid": true
+    }
+  ],
+  "lines": [
+    {
+      "feet": [
+        {
+          "syllables": [
+            {
+              "text": "சுடர்",
+              "syllable_type": "Nirai",
+              "split_hint": null,
+              "alt_split": false,
+              "rule_ref": "Nirai (triplet)",
+              "line_index": 0,
+              "word_index_in_line": 0
+            },
+            {
+              "text": "தொடீ",
+              "syllable_type": "Nirai",
+              "split_hint": null,
+              "alt_split": false,
+              "rule_ref": "Nirai/Ner (pair)",
+              "line_index": 0,
+              "word_index_in_line": 0
+            },
+            {
+              "text": "இ",
+              "syllable_type": "Ner",
+              "split_hint": null,
+              "alt_split": false,
+              "rule_ref": "Nirai/Ner (pair)",
+              "line_index": 0,
+              "word_index_in_line": 0
+            }
+          ],
+          "foot_type": "Nirai-Nirai-Ner"
+        },
+        {
+          "syllables": [
+            {
+              "text": "கே",
+              "syllable_type": "Ner",
+              "split_hint": null,
+              "alt_split": false,
+              "rule_ref": "Nirai/Ner (pair)",
+              "line_index": 0,
+              "word_index_in_line": 1
+            },
+            {
+              "text": "ளாய்",
+              "syllable_type": "Ner",
+              "split_hint": null,
+              "alt_split": false,
+              "rule_ref": "Nirai/Ner (pair)",
+              "line_index": 0,
+              "word_index_in_line": 1
+            }
+          ],
+          "foot_type": "Ner-Ner"
+        },
+        {
+          "syllables": [
+            {
+              "text": "தெரு",
+              "syllable_type": "Nirai",
+              "split_hint": null,
+              "alt_split": false,
+              "rule_ref": "Nirai/Ner (pair)",
+              "line_index": 0,
+              "word_index_in_line": 2
+            },
+            {
+              "text": "வில்",
+              "syllable_type": "Ner",
+              "split_hint": null,
+              "alt_split": false,
+              "rule_ref": "Nirai/Ner (pair)",
+              "line_index": 0,
+              "word_index_in_line": 2
+            },
+            {
+              "text": "நாம்",
+              "syllable_type": "Ner",
+              "split_hint": null,
+              "alt_split": false,
+              "rule_ref": "Nirai/Ner (pair)",
+              "line_index": 0,
+              "word_index_in_line": 2
+            }
+          ],
+          "foot_type": "Nirai-Ner-Ner"
+        }
+      ],
+      "line_class": "—"
+    },
+    {
+      "feet": [
+        {
+          "syllables": [
+            {
+              "text": "மணற்",
+              "syllable_type": "Nirai",
+              "split_hint": null,
+              "alt_split": false,
+              "rule_ref": "Nirai (triplet)",
+              "line_index": 1,
+              "word_index_in_line": 0
+            },
+            {
+              "text": "சிற்",
+              "syllable_type": "Ner",
+              "split_hint": null,
+              "alt_split": false,
+              "rule_ref": "Nirai/Ner (pair)",
+              "line_index": 1,
+              "word_index_in_line": 0
+            },
+            {
+              "text": "றில்",
+              "syllable_type": "Ner",
+              "split_hint": null,
+              "alt_split": false,
+              "rule_ref": "Nirai/Ner (pair)",
+              "line_index": 1,
+              "word_index_in_line": 0
+            }
+          ],
+          "foot_type": "Nirai-Ner-Ner"
+        },
+        {
+          "syllables": [
+            {
+              "text": "கா",
+              "syllable_type": "Ner",
+              "split_hint": null,
+              "alt_split": false,
+              "rule_ref": "Nirai/Ner (pair)",
+              "line_index": 1,
+              "word_index_in_line": 1
+            },
+            {
+              "text": "லில்",
+              "syllable_type": "Ner",
+              "split_hint": null,
+              "alt_split": false,
+              "rule_ref": "Nirai/Ner (pair)",
+              "line_index": 1,
+              "word_index_in_line": 1
+            }
+          ],
+          "foot_type": "Ner-Ner"
+        },
+        {
+          "syllables": [
+            {
+              "text": "சிதை",
+              "syllable_type": "Nirai",
+              "split_hint": null,
+              "alt_split": false,
+              "rule_ref": "Nirai/Ner (pair)",
+              "line_index": 1,
+              "word_index_in_line": 2
+            },
+            {
+              "text": "யா",
+              "syllable_type": "Ner",
+              "split_hint": null,
+              "alt_split": false,
+              "rule_ref": "Nirai/Ner (pair)",
+              "line_index": 1,
+              "word_index_in_line": 2
+            }
+          ],
+          "foot_type": "Nirai-Ner"
+        },
+        {
+          "syllables": [
+            {
+              "text": "அடை",
+              "syllable_type": "Nirai",
+              "split_hint": null,
+              "alt_split": false,
+              "rule_ref": "Nirai/Ner (pair)",
+              "line_index": 1,
+              "word_index_in_line": 3
+            }
+          ],
+          "foot_type": "Nirai"
+        }
+      ],
+      "line_class": "—"
+    },
+    {
+      "feet": [
+        {
+          "syllables": [
+            {
+              "text": "கோ",
+              "syllable_type": "Ner",
+              "split_hint": null,
+              "alt_split": false,
+              "rule_ref": "Nirai/Ner (pair)",
+              "line_index": 2,
+              "word_index_in_line": 0
+            },
+            {
+              "text": "தை",
+              "syllable_type": "Ner",
+              "split_hint": null,
+              "alt_split": false,
+              "rule_ref": "Nirai/Ner (pair)",
+              "line_index": 2,
+              "word_index_in_line": 0
+            }
+          ],
+          "foot_type": "Ner-Ner"
+        },
+        {
+          "syllables": [
+            {
+              "text": "பரிந்",
+              "syllable_type": "Nirai",
+              "split_hint": null,
+              "alt_split": false,
+              "rule_ref": "Nirai (triplet)",
+              "line_index": 2,
+              "word_index_in_line": 1
+            },
+            {
+              "text": "து",
+              "syllable_type": "Ner",
+              "split_hint": null,
+              "alt_split": false,
+              "rule_ref": "Nirai/Ner (pair)",
+              "line_index": 2,
+              "word_index_in_line": 1
+            }
+          ],
+          "foot_type": "Nirai-Ner"
+        },
+        {
+          "syllables": [
+            {
+              "text": "வரிப்",
+              "syllable_type": "Nirai",
+              "split_hint": null,
+              "alt_split": false,
+              "rule_ref": "Nirai (triplet)",
+              "line_index": 2,
+              "word_index_in_line": 2
+            },
+            {
+              "text": "பந்",
+              "syllable_type": "Ner",
+              "split_hint": null,
+              "alt_split": false,
+              "rule_ref": "Nirai/Ner (pair)",
+              "line_index": 2,
+              "word_index_in_line": 2
+            },
+            {
+              "text": "து",
+              "syllable_type": "Ner",
+              "split_hint": null,
+              "alt_split": false,
+              "rule_ref": "Nirai/Ner (pair)",
+              "line_index": 2,
+              "word_index_in_line": 2
+            }
+          ],
+          "foot_type": "Nirai-Ner-Ner"
+        },
+        {
+          "syllables": [
+            {
+              "text": "கொண்",
+              "syllable_type": "Ner",
+              "split_hint": null,
+              "alt_split": false,
+              "rule_ref": "Nirai/Ner (pair)",
+              "line_index": 2,
+              "word_index_in_line": 3
+            },
+            {
+              "text": "டோ",
+              "syllable_type": "Ner",
+              "split_hint": null,
+              "alt_split": false,
+              "rule_ref": "Nirai/Ner (pair)",
+              "line_index": 2,
+              "word_index_in_line": 3
+            }
+          ],
+          "foot_type": "Ner-Ner"
+        }
+      ],
+      "line_class": "—"
+    }
+  ],
+  "metre_type": "Venpaa",
+  "top_k_metre_hypotheses": [
+    {
+      "metre_type": "Venpaa",
+      "aggregate_score": 70,
+      "violations": [],
+      "rule_ids": [
+        "MetreLength01",
+        "LinkageAdjacency01"
+      ]
+    }
+  ],
+  "confidence": 70,
+  "provenance": [
+    "MetreLength01",
+    "LinkageAdjacency01"
+  ],
+  "errors": []
+}

--- a/src/lib/__tests__/livePreviewEditScenarios.test.ts
+++ b/src/lib/__tests__/livePreviewEditScenarios.test.ts
@@ -1,31 +1,34 @@
 /**
- * Live preview / layout contracts under aggressive poem edits.
+ * Live preview layout: editor physical lines ↔ `parsed.lines` ↔ `feetPerPhysicalLine`.
  *
- * **Goals**
- * - Document expected behaviour: editor physical lines ↔ WASM `parsed.lines` ↔ `feetPerPhysicalLine`.
- * - Integration tests run **only** when a WASM bundle exists (`pnpm run build:wasm` → `public/wasm/` or `src/wasm/`).
+ * The multi-line sample uses **committed real parser output** (`samplePoemThreeLines.parseResult.json`)
+ * so tests never hand-invent Ner/Nirai on Tamil surface forms.
  *
- * **Failures here are learning signals** — fix implementation until these pass in CI (after WASM build step).
+ * WASM integration tests run only when a bundle exists (`pnpm run build:wasm`).
  */
 
-import { describe, expect, it, beforeAll } from 'vitest'
+import { beforeAll, describe, expect, it } from 'vitest'
 
 import { feetPerPhysicalLine, groupsFromFeet } from '#/lib/parserFeetLayout'
 import { normalizePoemText } from '#/lib/poemTextNormalize'
 import { physicalPoemLines } from '#/lib/mapFeetToPhysicalLines'
-import type { ParsedPoem } from '#/types/parsedPoem'
 
 import {
+  assertSamplePhysicalLineCount,
+  parsedSampleFirstTwoLines,
+  parsedSampleThreeLines,
+  SAMPLE_POEM_THREE_LINES,
+} from '#/lib/__tests__/fixtures/samplePoemThreeLines.fixture'
+import {
   createWasmParsePoem,
+  createWasmParseRaw,
   isWasmPkgBuilt,
   type WasmParseFn,
+  type WasmParseRawFn,
 } from '#/lib/__tests__/wasmParseHarness'
+import { adaptWasmJsonToParsedPoem } from '#/lib/adaptWasmParseJson'
 
-/** Same poem shape as mobile repro — multi-line Tamil with spaces & newline endings */
-export const SAMPLE_POEM_THREE_LINES = `சுடர்த்தொடீஇ கேளாய் தெருவில்நாம்
-மணற்சிற்றில் காலில் சிதையா அடை
-கோதை பரிந்து வரிப்பந்து கொண்டோ
-`
+export { SAMPLE_POEM_THREE_LINES }
 
 function totalFeet(buckets: ReturnType<typeof feetPerPhysicalLine>): number {
   return buckets.reduce((n, row) => n + row.length, 0)
@@ -42,10 +45,6 @@ function flattenFootSyllableTexts(lineFeet: ReturnType<typeof feetPerPhysicalLin
   return lineFeet.flatMap((ft) => ft.syllables.map((s) => s.text))
 }
 
-/**
- * When legacy `lines` collapses the whole poem into `lines[0]`, the first row has chips and later rows are empty
- * (mobile bug: "first line shows entire poem"). Multi-line + non-empty first row + empty rest + many syllables only on row0.
- */
 function isFirstRowOnlyEntirePoemLayout(
   buckets: ReturnType<typeof feetPerPhysicalLine>,
   totalSyllablesInParse: number,
@@ -59,43 +58,10 @@ function isFirstRowOnlyEntirePoemLayout(
 }
 
 describe('live preview layout (no WASM)', () => {
-  it('physicalPoemLines count matches structured.lines → feet buckets get syllables', () => {
-    const poemText = 'ஒன்று இரண்டு\nமூன்று நான்கு\n'
-    const parsed: ParsedPoem = {
-      original_text: poemText,
-      metre_type: '—',
-      letter_count: 0,
-      vikalpa_count: 0,
-      syllables: [],
-      lines: [
-        {
-          line_class: '—',
-          feet: [
-            {
-              foot_type: 'Ner-Ner',
-              syllables: [{ text: 'ஒன்று', syllable_type: 'Ner' }],
-            },
-            {
-              foot_type: 'Nirai',
-              syllables: [{ text: 'இரண்டு', syllable_type: 'Nirai' }],
-            },
-          ],
-        },
-        {
-          line_class: '—',
-          feet: [
-            {
-              foot_type: 'Ner',
-              syllables: [{ text: 'மூன்று', syllable_type: 'Ner' }],
-            },
-            {
-              foot_type: 'Ner',
-              syllables: [{ text: 'நான்கு', syllable_type: 'Ner' }],
-            },
-          ],
-        },
-      ],
-    }
+  it('first two lines of the sample poem: real parser feet align with physical lines', () => {
+    assertSamplePhysicalLineCount()
+    const parsed = parsedSampleFirstTwoLines()
+    const poemText = parsed.original_text
 
     expect(physicalPoemLines(poemText).length).toBe(parsed.lines.length)
 
@@ -111,23 +77,12 @@ describe('live preview layout (no WASM)', () => {
 
   it('when editor lines ≠ structured.lines, buckets are empty (no wrong-row bleed)', () => {
     const poemText = 'a\nb\n'
-    const parsed: ParsedPoem = {
-      original_text: poemText,
-      metre_type: '—',
-      letter_count: 0,
-      vikalpa_count: 0,
-      syllables: [],
-      lines: [
-        {
-          line_class: '—',
-          feet: [{ foot_type: 'Ner', syllables: [{ text: 'x', syllable_type: 'Ner' }] }],
-        },
-      ],
-    }
+    const parsed = parsedSampleThreeLines()
+    const oneLine = { ...parsed, lines: [parsed.lines[0]!] }
     expect(physicalPoemLines(poemText).length).toBe(2)
-    expect(parsed.lines.length).toBe(1)
+    expect(oneLine.lines.length).toBe(1)
 
-    const buckets = feetPerPhysicalLine(parsed, poemText)
+    const buckets = feetPerPhysicalLine(oneLine, poemText)
     expect(buckets.every((row) => row.length === 0)).toBe(true)
   })
 
@@ -138,9 +93,10 @@ describe('live preview layout (no WASM)', () => {
 
 describe.skipIf(!isWasmPkgBuilt())('live preview + WASM integration', () => {
   let parsePoem: WasmParseFn
+  let parseRaw: WasmParseRawFn
 
   beforeAll(async () => {
-    parsePoem = await createWasmParsePoem()
+    ;[parsePoem, parseRaw] = await Promise.all([createWasmParsePoem(), createWasmParseRaw()])
   })
 
   it('parses sample poem and returns structured lines count matching physicalPoemLines', async () => {
@@ -220,8 +176,7 @@ describe.skipIf(!isWasmPkgBuilt())('live preview + WASM integration', () => {
     const parsed = await parsePoem(text)
     expect(parsed).not.toBeNull()
     const buckets = feetPerPhysicalLine(parsed!, text)
-    const tot = totalSyllablesFromBuckets(buckets)
-    expect(tot).toBe(parsed!.syllables.length)
+    expect(totalSyllablesFromBuckets(buckets)).toBe(parsed!.syllables.length)
     const maxSingleRow = Math.max(
       ...buckets.map((row) => flattenFootSyllableTexts(row).length),
       0,
@@ -229,7 +184,7 @@ describe.skipIf(!isWasmPkgBuilt())('live preview + WASM integration', () => {
     expect(maxSingleRow).toBeLessThan(parsed!.syllables.length)
   })
 
-  it('edit simulations: deleting lines / fragments never stacks entire poem on physical row 0 when counts align', async () => {
+  it('deleting lines or fragments: no “whole poem on row 0” when counts stay aligned', async () => {
     const variants = [
       SAMPLE_POEM_THREE_LINES.split('\n').slice(0, 2).join('\n') + '\n',
       SAMPLE_POEM_THREE_LINES.replace(/\n.+$/s, ''),
@@ -248,19 +203,16 @@ describe.skipIf(!isWasmPkgBuilt())('live preview + WASM integration', () => {
     }
   })
 
-  it('adaptWasmJsonToParsedPoem round-trip matches parse_poem_wasm JSON shape', async () => {
+  it('WASM output matches committed fixture (adapter parity)', async () => {
     const text = SAMPLE_POEM_THREE_LINES
-    const parsed = await parsePoem(text)
-    expect(parsed).not.toBeNull()
-    expect(parsed!.original_text).toBeTruthy()
-    expect(Array.isArray(parsed!.lines)).toBe(true)
-  })
-})
-
-describe('live preview controller cache key contract (documented behaviour)', () => {
-  it('same normalizePoemText(editor) === normalizePoemText(parsed.original_text) implies cache hit path', () => {
-    const editor = 'அஃ கு '
-    const parsedNorm = normalizePoemText(editor)
-    expect(parsedNorm).toBe(normalizePoemText(editor))
+    const raw = await parseRaw(text)
+    expect(raw).not.toBeNull()
+    const viaAdapter = adaptWasmJsonToParsedPoem(raw!)
+    const fixture = parsedSampleThreeLines()
+    expect(viaAdapter).not.toBeNull()
+    expect(viaAdapter!.lines.length).toBe(fixture.lines.length)
+    expect(viaAdapter!.lines.map((ln) => ln.feet.length)).toEqual(fixture.lines.map((ln) => ln.feet.length))
+    const viaHarness = await parsePoem(text)
+    expect(viaHarness!.lines.map((ln) => ln.feet.length)).toEqual(fixture.lines.map((ln) => ln.feet.length))
   })
 })

--- a/src/lib/__tests__/parserFeetLayout.test.ts
+++ b/src/lib/__tests__/parserFeetLayout.test.ts
@@ -3,6 +3,11 @@ import { describe, expect, it } from 'vitest'
 import { feetPerPhysicalLine, groupsFromFeet } from '#/lib/parserFeetLayout'
 import type { ParsedPoem } from '#/types/parsedPoem'
 
+import {
+  parsedSampleFirstTwoLines,
+  parsedSampleThreeLines,
+} from '#/lib/__tests__/fixtures/samplePoemThreeLines.fixture'
+
 function poem(lines: ParsedPoem['lines']): ParsedPoem {
   return {
     original_text: '',
@@ -15,32 +20,15 @@ function poem(lines: ParsedPoem['lines']): ParsedPoem {
 }
 
 describe('feetPerPhysicalLine', () => {
-  it('uses structured lines when count matches physical lines', () => {
-    const p = poem([
-      {
-        line_class: '—',
-        feet: [
-          {
-            foot_type: 'Ner-Ner',
-            syllables: [{ text: 'ab', syllable_type: 'Ner' }],
-          },
-        ],
-      },
-      {
-        line_class: '—',
-        feet: [
-          {
-            foot_type: 'Nirai',
-            syllables: [{ text: 'cd', syllable_type: 'Nirai' }],
-          },
-        ],
-      },
-    ])
-    const text = 'first line\nsecond'
-    const buckets = feetPerPhysicalLine(p, text)
+  it('uses structured lines when physical line count matches parsed.lines', () => {
+    const { original_text, lines } = parsedSampleFirstTwoLines()
+    const p = poem(lines)
+    const full = parsedSampleThreeLines()
+    const buckets = feetPerPhysicalLine({ ...full, original_text, lines }, original_text)
     expect(buckets).toHaveLength(2)
-    expect(buckets[0]![0]!.syllables[0]!.text).toBe('ab')
-    expect(buckets[1]![0]!.syllables[0]!.text).toBe('cd')
+    expect(buckets[0]!.length).toBe(lines[0]!.feet.length)
+    expect(buckets[1]!.length).toBe(lines[1]!.feet.length)
+    expect(buckets[0]![0]!.syllables[0]!.text).toBe(lines[0]!.feet[0]!.syllables[0]!.text)
   })
 
   it('returns empty feet per line when parser line count mismatches (avoid wrong-row slices)', () => {
@@ -59,25 +47,12 @@ describe('feetPerPhysicalLine', () => {
 })
 
 describe('groupsFromFeet', () => {
-  it('one group per foot with concatenated word label', () => {
-    const g = groupsFromFeet([
-      {
-        foot_type: 'Ner-Nirai',
-        syllables: [
-          { text: 'நண்', syllable_type: 'Ner' },
-          { text: 'ணு', syllable_type: 'Nirai' },
-        ],
-      },
-      {
-        foot_type: 'Ner-Nirai',
-        syllables: [
-          { text: 'வார்', syllable_type: 'Ner' },
-          { text: 'வினை', syllable_type: 'Nirai' },
-        ],
-      },
-    ])
+  it('one UI group per foot; word label is syllable texts joined (real parser feet)', () => {
+    const sample = parsedSampleThreeLines()
+    const feet = sample.lines[0]!.feet.slice(0, 2)
+    const g = groupsFromFeet(feet)
     expect(g).toHaveLength(2)
-    expect(g[0]!.word).toBe('நண்ணு')
-    expect(g[1]!.word).toBe('வார்வினை')
+    expect(g[0]!.word).toBe(feet[0]!.syllables.map((s) => s.text).join(''))
+    expect(g[1]!.word).toBe(feet[1]!.syllables.map((s) => s.text).join(''))
   })
 })

--- a/tamil-seiyul-alagi/examples/dump_live_preview_fixture.rs
+++ b/tamil-seiyul-alagi/examples/dump_live_preview_fixture.rs
@@ -1,0 +1,28 @@
+//! Regenerate `src/lib/__tests__/fixtures/samplePoemThreeLines.parseResult.json`.
+//!
+//! Mirrors `parse_poem_wasm` defaults (`uyir_u = true`, other options default).
+//! Run from repo root:
+//! `cd tamil-seiyul-alagi && cargo run --example dump_live_preview_fixture`
+
+use std::fs;
+use std::path::Path;
+
+use serde_json;
+use thepulimaangani_parser::{parse_poem, ParseOptions};
+
+const SAMPLE: &str = "சுடர்த்தொடீஇ கேளாய் தெருவில்நாம்\nமணற்சிற்றில் காலில் சிதையா அடை\nகோதை பரிந்து வரிப்பந்து கொண்டோ\n";
+
+fn main() {
+    let mut options = ParseOptions::default();
+    options.uyir_u = true;
+    let result = parse_poem(SAMPLE, options).expect("sample poem must parse");
+
+    let json = serde_json::to_string_pretty(&result).expect("serialize");
+    let out = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../src/lib/__tests__/fixtures/samplePoemThreeLines.parseResult.json");
+    if let Some(parent) = out.parent() {
+        fs::create_dir_all(parent).unwrap_or_else(|e| panic!("mkdir {}: {e}", parent.display()));
+    }
+    fs::write(&out, json).unwrap_or_else(|e| panic!("write {}: {e}", out.display()));
+    eprintln!("Wrote {}", out.display());
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
     "noEmit": true,
+    "resolveJsonModule": true,
 
     /* Linting */
     "skipLibCheck": true,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Layout tests used hand-written Tamil + `syllable_type` / `foot_type` values that did not match the real parser (misleading for readers and brittle).

## Approach

1. **Committed real output** — `samplePoemThreeLines.parseResult.json` is a full `ParseResult` from `parse_poem` with the same defaults as `parse_poem_wasm` (`uyir_u = true`).
2. **`samplePoemThreeLines.fixture.ts`** — imports JSON, runs `adaptWasmJsonToParsedPoem` (same path as production), exposes `parsedSampleThreeLines()`, `parsedSampleFirstTwoLines()` for the no-WASM case, and `assertSamplePhysicalLineCount()` for fixture drift.
3. **`tamil-seiyul-alagi/examples/dump_live_preview_fixture.rs`** — regenerates the JSON after parser changes.
4. **`pnpm run dump:test-fixture`** — convenience wrapper.
5. **`tsconfig.json`** — `resolveJsonModule: true` for the fixture import.
6. **`livePreviewEditScenarios`** / **`parserFeetLayout`** — use real feet; mismatch test reuses full sample with a single-line slice; WASM integration asserts feet-per-line parity with the fixture.

## Regenerate fixture

`pnpm run dump:test-fixture`

## Verification

- `cargo test` (tamil-seiyul-alagi)
- `pnpm exec vitest run` on the two updated test files (WASM tests skipped without bundle)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6f765198-808e-4c1f-9512-4a9dfaff0a15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6f765198-808e-4c1f-9512-4a9dfaff0a15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

