### PR TITLE
fix: syncagents exits 0 when no branches to push

### DIFF
--- a/dx/syncagents.sh
+++ b/dx/syncagents.sh
@@ -179,7 +179,8 @@ sync() {
                 echo "→ Cleaning up old branches..."
                 local count=0
                 while IFS= read -r b; do
-                    git branch -D "$b" --quiet && echo "   🗑 Deleted $b" && ((count++))
+                    # Use ++count: ((count++)) exits 1 when old value is 0 under set -e
+                    git branch -D "$b" --quiet && echo "   🗑 Deleted $b" && ((++count))
                 done < <(git branch --format='%(refname:short)' | grep -- '--to-be-deleted$' || true)
                 [ "$count" -gt 0 ] && echo "   ✓ Cleaned $count branch(es)"
                 ;;
@@ -203,10 +204,11 @@ sync() {
     if [ "$PUSH" = "1" ]; then
         echo ""
         echo "→ Pushing all branches with --force-with-lease..."
+        # Empty input: `while read` exits 1 — would trip set -e + pipefail without || true
         git branch --format='%(refname:short)' | grep -vE "^(${MAIN_BRANCH}|legacy)$" | while read -r b; do
             echo "   Pushing $b..."
             git push --force-with-lease origin "$b" --quiet && echo "   ✓ Pushed" || echo "   ⚠ Skipped"
-        done
+        done || true
     else
         echo ""
         echo "→ Push skipped (use PUSH=1 to push)"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`PUSH=1 ./dx/syncagents.sh` failed with exit code 1 when the only local branches were `malar` and `legacy`, because an empty `while read` loop returns 1 under `set -euo pipefail`.

Also replace `((count++))` with `((++count))` in the cleanup loop so the first successful delete does not trip `set -e` (arithmetic postfix increment returns the old value; when it is 0 the compound command status is 1).

After this change, `PUSH=1 ./dx/syncagents.sh` completes with the success banner and exit 0 when there is nothing to rebase or push besides updating `malar`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a47b2e7d-2ac0-46ad-93c7-c9f880a0c5fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a47b2e7d-2ac0-46ad-93c7-c9f880a0c5fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

