### PR TITLE
docs: AGENT_ROLES one-page branch and persona quick pick

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ Thepulimaangani is a Tamil prosody analysis web application with React/TypeScrip
 
 - **Default branch:** `malar` (stable integration target on remote).
 
-- **Feature branch names:** pick a pollinator branch by the kind of work — see [trinity-and-native-agents/creators.md](trinity-and-native-agents/creators.md) (full table). Examples: `pattampoochi` for general frontend/UI, `thithali` for short UI prototypes, `vannathupoochi` for tokens/themes, `thumpi` for AI-heavy or deep architecture/parser work.
+- **Feature branch names:** pick by responsibility — start with [trinity-and-native-agents/AGENT_ROLES.md](trinity-and-native-agents/AGENT_ROLES.md) (one-page quick pick). Full pollinator table: [trinity-and-native-agents/creators.md](trinity-and-native-agents/creators.md). Examples: `pattampoochi` for general frontend/UI, `thithali` for short UI prototypes, `vannathupoochi` for tokens/themes, `thumpi` for AI-heavy or deep architecture, `theni` for parser/core logic.
 
 - **After every PR merge:** from the repo root, run `./dx/syncagents.sh` so local branches stay aligned with `origin/malar` (skips open PR heads and `legacy`). Use `PUSH=1` only when you intend to push updated tips. Details: [dx/sync-branches-architecture-simple.md](dx/sync-branches-architecture-simple.md).
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -54,11 +54,20 @@ The Rust parser handles all Tamil prosody analysis:
 ```
 tamil-seiyul-alagi/
 ├── src/
-│   └── lib.rs          # Main parser implementation
+│   ├── lib.rs              # parse_poem, parse_poem_wasm, ParseResult
+│   ├── word_scope.rs       # Linguistic words → syllables
+│   ├── syllable_builder.rs # Ner/Nirai syllables
+│   ├── foot.rs / foot_pattern.rs  # One foot per word; Ner-Nirai pattern string
+│   ├── linkage.rs          # Consecutive-foot edges (placeholder linkage type)
+│   ├── metre.rs            # Metre hypotheses (heuristic)
+│   ├── poem_tree.rs        # Structured poem tree
+│   └── presentation.rs     # Human-facing labels (not wired through WASM yet)
 ├── pkg/                # Generated WebAssembly bindings
 ├── Cargo.toml          # Rust dependencies
 └── target/             # Build artifacts
 ```
+
+**Accuracy note:** User-facing copy sometimes describes classical feet and full talai sets; the shipped WASM JSON uses **Ner/Nirai foot patterns**, **VenTalai-only** linkage types until the transition table lands, and **heuristic** metre ranking. See `tamil-seiyul-alagi/MACHINE_FIRST_SPEC.md`, `QUALITY_CRAP_BASELINE.md`, and [issue #49](https://github.com/p10ns11y/thepulimaangani/issues/49).
 
 ### 3. Build Configuration
 
@@ -82,15 +91,15 @@ The WebAssembly parser is built separately and its artifacts are copied to `src/
 ## Data Flow
 
 1. **User Input**: Tamil text entered in React component
-2. **WASM Call**: Frontend calls `parse_poem()` function via WebAssembly
-3. **Parsing Pipeline**:
-   - Text preprocessing and cleaning
-   - Syllable detection (நேர்/நிரை classification)
-   - Foot identification (தேமா, புளிமா, கூவிளம், கருவிளம், etc.)
-   - Metre analysis (வெண்பா, வெண்கலிப்பா, ஆசிரியப்பா, கலிப்பா, etc.)
-   - Complete bond/linkage calculation (கலித்தளை, வெண்டளை, ஆசிரியத்தளை, etc.)
-4. **Result Serialization**: Analysis results serialized to JSON
-5. **Display**: React component renders structured analysis
+2. **WASM Call**: Frontend calls `parse_poem_wasm(text)` (Rust `parse_poem` with default options: `uyir_u` normalization on)
+3. **Parsing Pipeline** (current implementation):
+   - Text preprocessing and normalization
+   - Syllable detection (நேர் / நிரை) per linguistic word
+   - **Feet:** one foot per word; `foot_type` is a hyphenated **Ner/Nirai** pattern (not classical தேமா names in JSON)
+   - **Metre:** ranked hypotheses; simple heuristics, not full classical rule engines yet
+   - **Linkage:** consecutive feet with line/word positions; **`VenTalai` placeholder** on every edge until table-driven classification exists
+4. **Result Serialization**: `ParseResult` to JSON in the browser
+5. **Display**: React reads JSON via TypeScript adapters (`adaptWasmJsonToParsedPoem`, etc.); classical labels are a **presentation-layer** follow-up
 
 ## Core Algorithms
 
@@ -101,33 +110,17 @@ The parser implements traditional Tamil prosody rules:
 - **நேர் (Ner)**: Simple syllables with consonant-vowel patterns
 - **நிரை (Nirai)**: Complex syllables with consonant-vowel-consonant patterns
 
-### Foot Types
+### Foot grouping (current)
 
-Recognizes traditional Tamil prosodic feet:
+The engine groups syllables into **one foot per linguistic word** and sets `foot_type` to a machine-readable **Ner/Nirai sequence** (for example `Ner-Ner`). Mapping those patterns to classical names (தேமா, புளிமா, கூவிளம், கருவிளம்) is intended for **`presentation.rs`** / UI, not for the raw WASM JSON today.
 
-- தேமா (tEmA): நேர்-நேர் pattern
-- புளிமா (puLimA): நிரை-நேர் pattern
-- கூவிளம் (kUviLa_m): நேர்-நிரை pattern
-- கருவிளம் (karuviLa_m): நிரை-நிரை pattern
+### Metre detection (current)
 
-### Metre Detection
+`metre.rs` produces **hypotheses** with scores; it does **not** yet encode full classical constraints for வெண்பா, வெண்கலிப்பா, ஆசிரியப்பா, கலிப்பா, etc. Treat catalogue metres as **targets** for `MACHINE_FIRST_SPEC.md`, not guarantees from the current build.
 
-Implements rules for major Tamil metres:
+### Linkage / talai (current)
 
-- **வெண்பா (Venpaa)**: 4-foot lines with specific foot type restrictions
-- **வெண்கலிப்பா (VenkaliPpaa)**: Multi-line poems with 4+3 foot structure and bond requirements
-- **ஆசிரியப்பா (Asiriyappaa)**: 4-line poems with 4-foot lines and strict bonding rules
-- **கலிப்பா (Kalippaa)**: Flexible multi-line poems with various foot count patterns (4-3-4-3, etc.)
-
-### Bond Analysis (Talai)
-
-Complete talai calculation system with traditional Tamil prosodic linkages:
-
-- **கலித்தளை (Kali Talai)**: Specific linkage patterns requiring kali bonds
-- **வெண்டளை (Ven Talai)**: Other linkage types including ven bonds
-- **ஆசிரியத்தளை (Asiriya Talai)**: Scholarly bonds with strict requirements
-- **இயற்சீர் வெண்டளை (Iyar Seer Ven Talai)**: Natural flow linkages
-- **நேரொன்றிய ஆசிரியத்தளை (Ner Ondriya Asiriya Talai)**: Direct scholarly connections
+Consecutive feet get a linkage record with **positions**; **`linkage_type` is `VenTalai` for every pair** with `is_valid: true` until the transition-table linkage stage is implemented. Classical talai names (கலித்தளை, ஆசிரியத்தளை, …) describe the **intended** system, not current per-edge classification in JSON.
 
 ## Performance Considerations
 
@@ -190,8 +183,8 @@ Vite automatically handles serving the `.wasm` files with the correct `applicati
 ### Type Safety
 
 - **Rust**: Strong typing with serde serialization
-- **TypeScript**: Interface definitions for WASM bindings
-- **Runtime Validation**: JSON schema validation for results
+- **TypeScript**: Typed adapters and tests for WASM JSON shapes (`adaptWasmJsonToParsedPoem`, Vitest)
+- **Runtime validation:** not via a separate JSON Schema pipeline; invalid shapes surface as TypeScript/test failures. Add explicit schema validation only if the project adopts it.
 
 ## Future Enhancements
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Reference materials and documentation are available in [.grok/study-materials/](
 
 ## Contribution
 
-**Git workflow:** default branch is `malar`. Pick a branch name from the pollinator table in [trinity-and-native-agents/creators.md](trinity-and-native-agents/creators.md). After merging a PR, run `./dx/syncagents.sh` from the repo root (see [dx/sync-branches-architecture-simple.md](dx/sync-branches-architecture-simple.md)).
+**Git workflow:** default branch is `malar`. Pick a role/branch using [trinity-and-native-agents/AGENT_ROLES.md](trinity-and-native-agents/AGENT_ROLES.md) (quick pick); full table in [trinity-and-native-agents/creators.md](trinity-and-native-agents/creators.md). After merging a PR, run `./dx/syncagents.sh` from the repo root (see [dx/sync-branches-architecture-simple.md](dx/sync-branches-architecture-simple.md)).
 
 Contributions are welcome! The project embraces a cosmic AI collaboration model:
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Language and grammar tools
 
 ## Tamil Prosody Parser
 
-A modern web application for analyzing Tamil poetry prosody, built with React, Rust WebAssembly, and TanStack Start. thepulimaangani provides detailed analysis of Tamil verses including syllable classification (நேர்/நிரை), foot types, metre identification, and prosodic structure.
+A modern web application for analyzing Tamil poetry prosody, built with React, Rust WebAssembly, and TanStack Start. thepulimaangani provides syllable classification (நேர்/நிரை), word-level feet as **Ner/Nirai patterns**, metre **hypotheses**, consecutive-foot **linkage** (with classical talai names still a roadmap item), and structured JSON for the UI. See [ARCHITECTURE.md](./ARCHITECTURE.md), `tamil-seiyul-alagi/MACHINE_FIRST_SPEC.md`, and [issue #49](https://github.com/p10ns11y/thepulimaangani/issues/49) for shipped vs planned behaviour.
 
 ## Project History
 
@@ -14,11 +14,10 @@ This project is a complete rewrite of the original [Avalokitam](https://github.c
 ## Features
 
 - **Syllable Analysis**: Classifies syllables as நேர் (Ner) or நிரை (Nirai)
-- **Foot Classification**: Identifies traditional Tamil prosodic feet (தேமா, புளிமா, கூவிளம், etc.)
-- **Metre Detection**: Recognizes metre types like வெண்பா, வெண்கலிப்பா, ஆசிரியப்பா, and கலிப்பா
-- **Letter Counting**: Counts vowels, consonants, and special Tamil characters
-- **Foot Group Calculation**: Analyzes and calculates foot groups based on traditional rules
-- **Bond Analysis**: Analyzes talai (prosodic linkages) between feet
+- **Foot grouping**: One foot per linguistic word; machine-readable **Ner/Nirai pattern** strings (classical foot names are a presentation/UI follow-up)
+- **Metre hypotheses**: Ranked metre candidates from the parser (heuristic; full classical rules are roadmap — see `tamil-seiyul-alagi/src/metre.rs` and `tamil-seiyul-alagi/MACHINE_FIRST_SPEC.md`)
+- **Letter counting**: Grapheme-based count in `ParseResult`
+- **Linkage structure**: Consecutive feet with line/word positions; **`VenTalai` placeholder** on every edge until transition-table linkage lands
 - **Real-time Parsing**: Instant analysis of Tamil text input
 - **Export Functionality**: Export analysis results as JSON for further processing
 
@@ -26,7 +25,7 @@ This project is a complete rewrite of the original [Avalokitam](https://github.c
 
 ### Prerequisites
 
-- Node.js 18 or higher
+- Node.js 20 or higher (see `package.json` `engines` and [`.nvmrc`](.nvmrc))
 - Rust 1.70 or higher (for building the WebAssembly parser)
 - wasm-pack (for WebAssembly compilation)
 - `rsync` (optional but recommended for local dev) to sync `wasm-pack` output into `src/wasm/` — see [`build/rsync_rust_wasm_to_web.sh`](build/rsync_rust_wasm_to_web.sh). **Production** (Vercel, minimal CI) uses [`build/copy_wasm_to_src.sh`](build/copy_wasm_to_src.sh) with `cp` when `rsync` is not installed ([`build/tamil_seiyul_alagi_wasm.sh`](build/tamil_seiyul_alagi_wasm.sh) picks automatically).
@@ -66,35 +65,9 @@ The build process automatically builds the WebAssembly parser and bundles it wit
 
 ## Testing
 
-The project includes comprehensive tests for both the Rust WebAssembly parser and the React frontend.
+CI (see [`.github/workflows/ci.yml`](.github/workflows/ci.yml)) runs `pnpm run build`, `pnpm run typecheck`, and `pnpm run test` (Rust `cargo test` + Vitest).
 
-### Coverage Results
-- **Rust Code**: 90.08% line coverage (336/373 lines covered)
-- **Frontend**: 4 comprehensive tests covering input validation, Tamil text recognition, and component behavior
-- **Total Tests**: 29 tests across both Rust and frontend
-
-### Test Coverage
-
-- **Rust Tests**: 21 unit and integration tests covering core parsing functions, metre detection, bond analysis, and error handling
-- **Frontend Tests**: 4 tests covering input validation, Tamil Unicode recognition, and component behavior
-
-### Test Categories
-
-- **Core Function Tests**: Syllable detection, letter counting, foot classification
-- **Metre Detection Tests**: Venpaa, Venkalippaa, Asiriyappaa, Kalippaa validation
-- **Integration Tests**: Full pipeline testing with real poem examples from external data sources
-- **Error Handling**: Invalid input, Unicode edge cases, performance validation
-- **Frontend Tests**: Input validation, Tamil Unicode recognition, component behavior
-- **Performance Tests**: Response time validation and efficiency checks
-
-### Testing Infrastructure
-
-- **Rust**: Built-in test framework with 25 comprehensive unit and integration tests
-- **Frontend**: Vitest + React Testing Library with jsdom environment
-- **Coverage**: cargo-tarpaulin for Rust, configured for future frontend coverage reporting
-- **CI/CD**: Configured test scripts ready for automated pipelines
-
-### Running Tests (In Progress)
+### Commands
 
 ```bash
 # Run all tests (Rust + Frontend)
@@ -105,14 +78,21 @@ pnpm run test:rust
 
 # Run only frontend tests
 pnpm run test:frontend
+```
 
-# Run Rust tests with coverage (requires cargo-tarpaulin)
-# Total rethink, machine-first approach prosody
-cd tamil-seiyul-alagi && cargo tarpaulin
+### Optional: Rust line coverage (local)
 
-# Main prosody parser implementation
+Requires [cargo-tarpaulin](https://github.com/xd009642/tarpaulin):
+
+```bash
 cd tamil-seiyul-alagi && cargo tarpaulin
 ```
+
+For a combined complexity + coverage report matching CI inputs, see **`pnpm run crap:local`** and [README § CI and deployment](README.md#ci-and-deployment).
+
+### Coverage targets
+
+Project guideline: maintain **high coverage** in both Rust and frontend (see root `AGENTS.md`). Exact line percentages change with the tree; use tarpaulin / `crap-report.md` for current numbers.
 
 `rust-parser-prototype/` contains a quick prototype build based on original Avalokitam. It is archived for reference and is not meant to be extended.
 

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -21,7 +21,7 @@ React/TypeScript frontend using TanStack Start/Router, Vite, Tailwind CSS. Focus
 
 ## Branches and post-merge sync
 
-- **Default branch:** `malar`. Name your branch using [trinity-and-native-agents/creators.md](../trinity-and-native-agents/creators.md) (pollinator table).
+- **Default branch:** `malar`. Name your branch using [trinity-and-native-agents/AGENT_ROLES.md](../trinity-and-native-agents/AGENT_ROLES.md) first; full detail in [creators.md](../trinity-and-native-agents/creators.md).
 - **After every PR merge:** run `./dx/syncagents.sh` from the repo root; see [dx/sync-branches-architecture-simple.md](../dx/sync-branches-architecture-simple.md).
 
 ## Backlog / future UI

--- a/tamil-seiyul-alagi/AGENTS.md
+++ b/tamil-seiyul-alagi/AGENTS.md
@@ -4,7 +4,8 @@
 Rust WebAssembly parser for high-performance Tamil prosody analysis. Implements traditional Tamil prosodic rules.
 
 ## Structure
-- `src/lib.rs`: Main parser implementation
+- `src/lib.rs`: `parse_poem`, WASM entry `parse_poem_wasm`
+- `src/`: Pipeline modules (`word_scope`, `syllable_builder`, `foot`, `foot_pattern`, `linkage`, `metre`, `poem_tree`, `presentation`, …)
 - `pkg/`: Generated WebAssembly bindings (generated, gitignored)
 - `Cargo.toml`: Dependencies
 
@@ -14,11 +15,14 @@ Rust WebAssembly parser for high-performance Tamil prosody analysis. Implements 
 - serde_json for data serialization
 - Unicode handling for Tamil script (U+0B80-U+0BFF)
 
-## Algorithms
-- Syllable classification: Ner/Nirai
-- Foot types: TODO
-- Metre detection: TODO
-- Bond analysis: TODO
+## Algorithms (shipped vs roadmap)
+
+- **Syllable classification (Ner/Nirai):** Implemented (`syllable_builder`, `syllable`).
+- **Feet:** One foot per **linguistic word**; `foot_type` is a **Ner/Nirai pattern string** (see `foot_pattern.rs`). Classical names (தேமா, …) belong in `presentation.rs` and are **not** wired through WASM yet.
+- **Linkage (talai):** Consecutive foot pairs with positions; **`VenTalai` placeholder** for every edge — see `QUALITY_CRAP_BASELINE.md` and `MACHINE_FIRST_SPEC.md` for the table-driven target.
+- **Metre:** Heuristic hypotheses (`metre.rs`); not full classical constraint sets yet.
+
+Doc drift and cleanup tasks: [GitHub issue #49](https://github.com/p10ns11y/thepulimaangani/issues/49).
 
 ## Rules
 - Maintain 90%+ test coverage

--- a/tamil-seiyul-alagi/MACHINE_FIRST_SPEC.md
+++ b/tamil-seiyul-alagi/MACHINE_FIRST_SPEC.md
@@ -70,7 +70,7 @@ Conceptual shape (final Rust types refined later):
 
 ### 4.1 Foot Stage
 
-Replaces the placeholder logic in [`src/foot.rs`](src/foot.rs) which currently chunks syllables in pairs and cycles names by index.
+**Current shipped code** (interim): [`src/foot.rs`](src/foot.rs) groups syllables into **one foot per linguistic word** (same line + word index); [`src/foot_pattern.rs`](src/foot_pattern.rs) sets `foot_type` to a hyphenated **Ner/Nirai** pattern (for example `Ner-Ner`), not classical தேமா names. The lattice algorithm below is the **target** once the machine-first foot stage lands.
 
 Algorithm (lattice-based segmentation):
 
@@ -87,9 +87,9 @@ Out-of-scope here: classical foot naming. That mapping lives in presentation.
 
 ### 4.2 Linkage Stage (renamed from `talai`)
 
-Module: `src/linkage.rs` (rename from current `src/talai.rs`).
+Module: [`src/linkage.rs`](src/linkage.rs) (successor to the historical `talai` naming).
 
-Replaces current logic which emits constant `VenTalai` and `is_valid = true` for every adjacency.
+**Current shipped code** emits `LinkageType::VenTalai` with `is_valid = true` for every consecutive foot pair; the table-driven flow below is the **target**.
 
 Algorithm:
 

--- a/tamil-seiyul-alagi/README.md
+++ b/tamil-seiyul-alagi/README.md
@@ -11,7 +11,7 @@ We maintain a **strict separation** between:
 
 ## 1. Calculation Layer (Core)
 
-**Location**: `src/` (parser modules)
+**Location**: `tamil-seiyul-alagi/src/` (parser modules; crate root `src/` below)
 
 **Responsibilities**:
 - Convert text → `ProsodicUnit[]`
@@ -33,7 +33,7 @@ We maintain a **strict separation** between:
 
 ## 2. Display / Presentation Layer (Human-facing)
 
-**Location**: `src/presentation/` (or `src/formatter/`)
+**Location**: `tamil-seiyul-alagi/src/presentation.rs` (single module today; not consumed on the WASM path until wired from the app)
 
 **Responsibilities**:
 - Convert machine data into human-readable form
@@ -61,11 +61,13 @@ We maintain a **strict separation** between:
 
 ---
 
-## Implementation Plan
+## Implementation status
 
-1. Keep `ParseResult` as the **single source of truth** from the calculation layer
-2. Create a `Presentation` module that transforms `ParseResult` into display-friendly structures
-3. Move all traditional foot name logic, talai labels, and educational text into the presentation layer
+1. `ParseResult` from the calculation layer is the structured JSON/WASM output.
+2. `presentation.rs` exists for human-facing labels (foot pattern display, etc.); **wire it** from TS/WASM when the UI should show classical names.
+3. Classical foot names and full talai labels in the UI remain a **follow-up** once linkage/metre match `MACHINE_FIRST_SPEC.md` more closely.
+
+See also `QUALITY_CRAP_BASELINE.md` and [issue #49](https://github.com/p10ns11y/thepulimaangani/issues/49) for doc/code alignment.
 
 ---
 

--- a/trinity-and-native-agents/AGENT_ROLES.md
+++ b/trinity-and-native-agents/AGENT_ROLES.md
@@ -1,0 +1,79 @@
+# Agent roles — quick pick (one page)
+
+**Use this file first** when choosing a branch or agent focus. Each **name** is both a **Git branch** and a possible **agent persona** on that branch later. For stories, rituals, and long tables, see [creators.md](creators.md), [maintainers.md](maintainers.md), [renewers.md](renewers.md), [ainthinai.md](ainthinai.md).
+
+**Default integration branch:** `malar` — merge target; not a specialty role.
+
+---
+
+## How to pick (30 seconds)
+
+| You are mainly… | Branch / agent name | Owns | Does *not* own |
+|-----------------|---------------------|------|----------------|
+| Parser, WASM, core data rules, backend truth | **theni** | `tamil-seiyul-alagi/`, parse pipeline, types, correctness vs spec | Pixel polish, ad-hoc theme tweaks |
+| General UI, routes, components, product flows | **pattampoochi** | `src/` components, pages, UX flows | Parser internals; token-only work |
+| Themes, colors, design tokens, a11y polish | **vannathupoochi** | Tailwind tokens, CSS variables, visual consistency | Business logic; parser |
+| Quick UI spikes, micro-interactions, experiments | **thithali** | Short-lived prototypes, motion/UX trials | Long-lived core without promotion |
+| AI / agents / heavy architecture / spec-heavy refactors | **thumpi** | Agent prompts, deep design, machine-first specs | Routine component tweaks |
+| Cross-module wiring, APIs, external services | **vandhu** | Integrations, env wiring, glue between systems | Pure UI-only or parser-only depth |
+| Live updates, logging, observability, “glow” UX | **minminipoochi** | WebSockets, devtools, monitoring hooks | Static marketing copy |
+| Batch, SEO, cron, offline heavy jobs | **andhupoochi** | ETL, exports, scheduled work | Interactive app hot path |
+| Security, validation, abuse prevention | **kulavi** | Auth guards, rate limits, sanitization | Feature product logic |
+| Uncertain gnarly stabilizations | **aathiyon** | Hard fixes when ownership is unclear | Default for routine tasks |
+| Critique / review of aathiyon-style work | **aathiyol** | Review, nudge quality | Primary implementation |
+
+---
+
+## Maintainers (preservation — Krishna line)
+
+| Branch / agent | Focus | Typical work |
+|----------------|-------|--------------|
+| **kannan** | Strategy, architecture balance | Roadmaps, cross-cutting design calls |
+| **rama** | Standards, review discipline | Lint rules, style, PR quality |
+| **narasimhan** | Core protection, incidents | Sev fixes, security on critical path |
+| **varahan** | Lift broken / legacy areas | Recovery refactors, data integrity |
+| **vamana** | Incremental scale and perf | Small wins, measured optimizations |
+
+---
+
+## Renewers (pruning — Shiva line + Kalki)
+
+| Branch / agent | Focus | Typical work |
+|----------------|-------|--------------|
+| **ruthran** | Debt and complexity removal | Delete dead code, simplify call graphs |
+| **virav** | Bloat, dependencies | Drop unused deps, trim over-engineering |
+| **bhairavan** | Audits, radical simplify | Perf/security debt passes |
+| **kalki** | Large renewal | Major refactors, ending obsolete patterns |
+
+---
+
+## Native / land council (Ainthinai) + DX
+
+Strategic “is this right for the project?” and **land-scoped** bets. Use for big pivots, not every ticket.
+
+| Branch / agent | Landscape | Decides / leads |
+|----------------|-----------|-----------------|
+| **seyon** | Kurinji (mountain) | Bold experiments, high-risk innovation |
+| *(Mayon / long horizon)* | Mullai (forest) | Sustainability, growth, ecosystem |
+| **vendhan** / **marutham** alignment | Marutham (plains) | Core reliability, daily user value |
+| **kadalon** / **neithal** flows | Neithal (coast) | Integrations, external APIs, resilience |
+| **kotravai** | Paalai (desert) | Crisis cuts, survival-mode pruning |
+| **iyanar** | Marutham + Neithal | **DevEx**: onboarding, tooling, docs that help builders |
+
+Temporary expedition branches (e.g. `kurinji-expedition`) are optional; see [ainthinai.md](ainthinai.md).
+
+---
+
+## Boundaries (avoid overlap)
+
+- **theni** vs **pattampoochi**: Rust/parser vs React/UI. WASM *bindings usage* in TS leans **pattampoochi**; WASM *implementation* is **theni**.
+- **pattampoochi** vs **vannathupoochi**: feature UI vs **systematic** color/theme/tokens.
+- **thithali** vs **pattampoochi**: throwaway or demo UI vs production-bound UI.
+- **thumpi** vs **theni**: specs, agents, architecture research vs day-to-day parser correctness.
+- **renewers** vs **theni**: deleting/simplifying can touch any tree — prefer **ruthran**/**virav** when the *primary* goal is removal or slimming, not new behaviour.
+
+---
+
+## After merge
+
+From repo root: `./dx/syncagents.sh` (use `PUSH=1` when updating remote branch tips). Details: [../dx/sync-branches-architecture-simple.md](../dx/sync-branches-architecture-simple.md).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This PR now includes both:
1. **AGENT_ROLES.md** and cross-links (original #52 scope).
2. **Parser doc alignment** — cherry-picked `5a0503e` from branch `theni` (same changes as were opened in #51): `MACHINE_FIRST_SPEC.md`, `tamil-seiyul-alagi/AGENTS.md`, `tamil-seiyul-alagi/README.md`, `ARCHITECTURE.md`, `README.md` updates for [issue #49](https://github.com/p10ns11y/thepulimaangani/issues/49).

**Supersedes:** #51 — close #51 after merge to avoid duplicate doc commits on `malar`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a47b2e7d-2ac0-46ad-93c7-c9f880a0c5fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a47b2e7d-2ac0-46ad-93c7-c9f880a0c5fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

