### PR TITLE
docs: README quick start; move long docs to dx/DEVELOPER_GUIDE

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Thepulimaangani is a Tamil prosody analysis web application with React/TypeScrip
 - Typecheck: `pnpm run typecheck`
 
 ## Deployment (Vercel)
-- Full flow: [**CI and deployment** in README.md](README.md#ci-and-deployment). In short: [`vercel.json`](vercel.json) runs the wasm toolchain install, then `NITRO_PRESET=vercel pnpm run build`, and **`outputDirectory` is `.vercel/output`** (Nitro Build Output v3). Do not point the Vercel project at `dist` or `dist/client` only.
+- Full flow: [**CI and deployment** in `dx/DEVELOPER_GUIDE.md`](dx/DEVELOPER_GUIDE.md#ci-and-deployment). In short: [`vercel.json`](vercel.json) runs the wasm toolchain install, then `NITRO_PRESET=vercel pnpm run build`, and **`outputDirectory` is `.vercel/output`** (Nitro Build Output v3). Do not point the Vercel project at `dist` or `dist/client` only.
 
 ## Coding Style
 - TypeScript: Strict typing, no `any`

--- a/README.md
+++ b/README.md
@@ -1,181 +1,90 @@
-# Thepulimaangani 
+# Thepulimaangani
 
-Language and grammar tools
+Tamil prosody (யாப்பு) in the browser: React (TanStack Start) + Rust WebAssembly parser. See [ARCHITECTURE.md](./ARCHITECTURE.md) for stack and data flow.
 
+---
 
-## Tamil Prosody Parser
+## Quick start (about 5 minutes)
 
-A modern web application for analyzing Tamil poetry prosody, built with React, Rust WebAssembly, and TanStack Start. thepulimaangani provides syllable classification (நேர்/நிரை), word-level feet as **Ner/Nirai patterns**, metre **hypotheses**, consecutive-foot **linkage** (with classical talai names still a roadmap item), and structured JSON for the UI. See [ARCHITECTURE.md](./ARCHITECTURE.md), `tamil-seiyul-alagi/MACHINE_FIRST_SPEC.md`, and [issue #49](https://github.com/p10ns11y/thepulimaangani/issues/49) for shipped vs planned behaviour.
+Do these steps **in order** the first time you work on the repo.
 
-## Project History
+### 0. Prerequisites (install once on your machine)
 
-This project is a complete rewrite of the original [Avalokitam](https://github.com/virtualvinodh/avalokitam) project, which was built with PHP backend and Vue.js frontend. The new version maintains the same core functionality while adopting a modern web technology stack for improved performance, maintainability, and developer experience.
+| Tool | Why |
+|------|-----|
+| **Git** | Clone this repository |
+| **Node.js 20+** | Matches [`package.json`](package.json) `engines` and [`.nvmrc`](.nvmrc) |
+| **pnpm** | Package manager (`corepack enable` then `corepack prepare pnpm@10.33.0 --activate`, or install pnpm per [pnpm.io](https://pnpm.io/installation)) |
+| **Rust (stable)** + **rustup** | Builds the WASM parser |
+| **wasm-pack** | `cargo install wasm-pack` |
+| **`wasm32-unknown-unknown`** target | `rustup target add wasm32-unknown-unknown` |
 
-## Features
+Optional: **`rsync`** for faster local WASM copy (otherwise the build script uses `cp`). See [`build/tamil_seiyul_alagi_wasm.sh`](build/tamil_seiyul_alagi_wasm.sh).
 
-- **Syllable Analysis**: Classifies syllables as நேர் (Ner) or நிரை (Nirai)
-- **Foot grouping**: One foot per linguistic word; machine-readable **Ner/Nirai pattern** strings (classical foot names are a presentation/UI follow-up)
-- **Metre hypotheses**: Ranked metre candidates from the parser (heuristic; full classical rules are roadmap — see `tamil-seiyul-alagi/src/metre.rs` and `tamil-seiyul-alagi/MACHINE_FIRST_SPEC.md`)
-- **Letter counting**: Grapheme-based count in `ParseResult`
-- **Linkage structure**: Consecutive feet with line/word positions; **`VenTalai` placeholder** on every edge until transition-table linkage lands
-- **Real-time Parsing**: Instant analysis of Tamil text input
-- **Export Functionality**: Export analysis results as JSON for further processing
-
-## Installation
-
-### Prerequisites
-
-- Node.js 20 or higher (see `package.json` `engines` and [`.nvmrc`](.nvmrc))
-- Rust 1.70 or higher (for building the WebAssembly parser)
-- wasm-pack (for WebAssembly compilation)
-- `rsync` (optional but recommended for local dev) to sync `wasm-pack` output into `src/wasm/` — see [`build/rsync_rust_wasm_to_web.sh`](build/rsync_rust_wasm_to_web.sh). **Production** (Vercel, minimal CI) uses [`build/copy_wasm_to_src.sh`](build/copy_wasm_to_src.sh) with `cp` when `rsync` is not installed ([`build/tamil_seiyul_alagi_wasm.sh`](build/tamil_seiyul_alagi_wasm.sh) picks automatically).
-
-### Install Dependencies
+### 1. Clone and enter the repo
 
 ```bash
-# Install wasm-pack (one-time setup for Rust WebAssembly builds)
-cargo install wasm-pack
+git clone https://github.com/p10ns11y/thepulimaangani.git
+cd thepulimaangani
 ```
 
+### 2. Install Node dependencies
+
+Uses a pinned pnpm from `packageManager` in [`package.json`](package.json):
+
 ```bash
-# Install Node.js dependencies
+corepack enable
 pnpm install
 ```
 
-## Running the Application
+### 3. Run the development server
 
-### Development Mode
+`pnpm run dev` builds WASM once, then starts Vite on **http://localhost:3000**.
 
 ```bash
 pnpm run dev
 ```
 
-The application will be available at `http://localhost:3000`. 
+- **Frontend-only edits:** save files; Vite reloads.
+- **Rust parser edits:** run `pnpm run build:wasm`, then refresh (or restart `pnpm run dev`).
 
-The development server will automatically rebuild when you make changes to the frontend code, but you'll need to run `pnpm run build:wasm` if you modify the Rust parser.
+### 4. (Optional) Typecheck and tests
 
-### Production Build
+Same commands as CI:
+
+```bash
+pnpm run typecheck
+pnpm run test
+```
+
+---
+
+## Production build (local)
 
 ```bash
 pnpm run build
 pnpm run preview
 ```
 
-The build process automatically builds the WebAssembly parser and bundles it with the frontend application.
+---
 
-## Testing
+## Deployment
 
-CI (see [`.github/workflows/ci.yml`](.github/workflows/ci.yml)) runs `pnpm run build`, `pnpm run typecheck`, and `pnpm run test` (Rust `cargo test` + Vitest).
+Vercel must use **`.vercel/output`** (Nitro Build Output API v3), not `dist` alone. Full checklist: [**CI and deployment** in `dx/DEVELOPER_GUIDE.md`](dx/DEVELOPER_GUIDE.md#ci-and-deployment). Short summary for agents: [`AGENTS.md`](AGENTS.md).
 
-### Commands
+---
 
-```bash
-# Run all tests (Rust + Frontend)
-pnpm run test
+## More documentation
 
-# Run only Rust tests
-pnpm run test:rust
+| Doc | Contents |
+|-----|----------|
+| [`dx/DEVELOPER_GUIDE.md`](dx/DEVELOPER_GUIDE.md) | Testing, CRAP report, Vercel details, contribution links, study materials |
+| [`ARCHITECTURE.md`](ARCHITECTURE.md) | Frontend vs parser, WASM pipeline, shipped vs roadmap behaviour |
+| [`AGENTS.md`](AGENTS.md) | Commands, quality gates, Vercel note, branch sync |
+| [`trinity-and-native-agents/AGENT_ROLES.md`](trinity-and-native-agents/AGENT_ROLES.md) | Which Git branch / role to use for a task |
+| [`tamil-seiyul-alagi/MACHINE_FIRST_SPEC.md`](tamil-seiyul-alagi/MACHINE_FIRST_SPEC.md) | Machine-first parser spec (draft) |
 
-# Run only frontend tests
-pnpm run test:frontend
-```
-
-### Optional: Rust line coverage (local)
-
-Requires [cargo-tarpaulin](https://github.com/xd009642/tarpaulin):
-
-```bash
-cd tamil-seiyul-alagi && cargo tarpaulin
-```
-
-For a combined complexity + coverage report matching CI inputs, see **`pnpm run crap:local`** and [README § CI and deployment](README.md#ci-and-deployment).
-
-### Coverage targets
-
-Project guideline: maintain **high coverage** in both Rust and frontend (see root `AGENTS.md`). Exact line percentages change with the tree; use tarpaulin / `crap-report.md` for current numbers.
-
-`rust-parser-prototype/` contains a quick prototype build based on original Avalokitam. It is archived for reference and is not meant to be extended.
-
-## Architecture
-
-Thepulimaangani consists of:
-
-- **Frontend**: React application built with TanStack Start, using TanStack Router for routing and Tailwind CSS for styling
-- **Backend**: Rust WebAssembly module for high-performance Tamil prosody parsing
-- **Data Flow**: Text input → WebAssembly parser → JSON analysis → React display
-
-See [ARCHITECTURE.md](./ARCHITECTURE.md) for detailed technical documentation.
-
-## CI and deployment
-
-### GitHub Actions
-
-- **Workflow:** [`.github/workflows/ci.yml`](.github/workflows/ci.yml) runs on pushes to `malar` and `main` and on all pull requests: full `pnpm run build` (WebAssembly + Vite), `pnpm run typecheck`, and `pnpm run test` (Rust + Vitest). Node version matches [`.nvmrc`](.nvmrc).
-- **CRAP report:** Job `crap_analysis` uploads artifact **`crap-analysis`** (download from the run’s **Artifacts**). Open **`crap-report.md`** for the summary. Manual baseline notes live in [`tamil-seiyul-alagi/QUALITY_CRAP_BASELINE.md`](tamil-seiyul-alagi/QUALITY_CRAP_BASELINE.md).
-
-### CRAP report (local)
-
-Combines cyclomatic complexity (Lizard XML on the Rust parser tree) with line coverage (`cargo llvm-cov` + Vitest `coverage-summary.json`). Writes **`crap-report.md`** at the repo root.
-
-**Prerequisites (one-time):**
-
-- Python 3 + `pip install lizard` (CLI must be on `PATH` as `lizard`)
-- `rustup component add llvm-tools-preview` and `cargo install cargo-llvm-cov`
-
-**Run (matches CI inputs):**
-
-```bash
-pnpm run crap:local
-```
-
-Then open **`crap-report.md`**. Generated inputs (`lizard-rust.xml`, `tamil-seiyul-alagi/llvm-cov-summary.json`, `coverage/`) are gitignored; re-run the command when you want a fresh report.
-
-### Vercel (this repo’s working flow)
-
-These pieces work together; changing one in isolation (for example, pointing the project at `dist` only) can produce a **blank page** or **404 on `/`**.
-
-1. **Install** — [`vercel.json`](vercel.json) `installCommand` runs [`build/ensure-wasm-build-tools.sh`](build/ensure-wasm-build-tools.sh) (`rustup` when needed, the `wasm32-unknown-unknown` target, and a pinned `wasm-pack` binary on `PATH`), then `corepack enable` and `pnpm install --frozen-lockfile`. The Node version comes from the Vercel build image and [`.nvmrc`](.nvmrc) / `engines`. The subsequent `pnpm run build` compiles the Rust parser and copies WASM into [`src/wasm/`](AGENTS.md) (gitignored). The first Vercel build can take several minutes.
-
-2. **Build** — `buildCommand` is `NITRO_PRESET=vercel pnpm run build`. The `NITRO_PRESET=vercel` prefix forces Nitro’s **vercel** preset and a [Build Output API v3](https://vercel.com/docs/build-output-api/v3) bundle under [`.vercel/output`](https://vercel.com/docs/build-output-api/v3#directory-structure) (`config.json`, `static/`, `functions/__server*`). A normal local or CI `pnpm run build` (without that prefix) still writes `dist/` and `.output/` for `vite preview` and tests.
-
-3. **Output directory** — `outputDirectory` in `vercel.json` is **`.vercel/output`**. Vercel must deploy that directory. It overrides a mistaken **Output Directory** in the dashboard (for example `dist` or `dist/client`) that would deploy only the Vite client tree. Build logs that list `client/assets/...` and hashed JS/CSS/WASM are expected: those are the client artifacts; the **HTML for `/` is still rendered by the serverless function**, not by a root `index.html` in `dist/`.
-
-4. **Vite** — [`vite.config.ts`](vite.config.ts) uses [`tanstackStart()`](https://tanstack.com/start/latest) and [`nitro()`](https://v3.nitro.build/) (no manual `preset` in code; the `NITRO_PRESET` env from step 2 selects the Vercel preset on deploy). This matches the [TanStack Start on Vercel](https://vercel.com/docs/frameworks/full-stack/tanstack-start) guidance.
-
-**Production vs preview** (Vercel dashboard, not in `vercel.json`): In **Project → Settings → Git**, set **Production Branch** to `malar` for the production URL. **Pull requests** from connected branches get **Preview** deployments; if they are missing, check the same **Git** section and [deployment protection](https://vercel.com/docs/deployment-protection) / team policy.
-
-### Other hosts
-
-- **Cloudflare Pages:** the same `pnpm run build` can be a starting point, but a **static** root of `dist` alone is often wrong for TanStack Start—use current **TanStack Start + Cloudflare** docs for full-stack or worker routing.
-
-## Study Materials
-
-Reference materials and documentation are available in [.grok/study-materials/](./.grok/study-materials/) for development and research purposes.
-
-## Usage
-
-1. Enter Tamil poetry text in the textarea (or use the "Load Sample Poem" button)
-2. Click "Parse Poem" to analyze the prosody
-3. View detailed analysis including:
-   - Original text
-   - Metre type
-   - Letter counts (vowels, consonants, etc.)
-   - Prosodic structure with syllables, feet, and foot groups
-   - Error messages if parsing fails
-4. Export results as JSON or copy to clipboard for further use
-
-## Contribution
-
-**Git workflow:** default branch is `malar`. Pick a role/branch using [trinity-and-native-agents/AGENT_ROLES.md](trinity-and-native-agents/AGENT_ROLES.md) (quick pick); full table in [trinity-and-native-agents/creators.md](trinity-and-native-agents/creators.md). After merging a PR, run `./dx/syncagents.sh` from the repo root (see [dx/sync-branches-architecture-simple.md](dx/sync-branches-architecture-simple.md)).
-
-Contributions are welcome! The project embraces a cosmic AI collaboration model:
-
-- **[Creators](/trinity-and-native-agents/creators.md)** — Feature creation & pollinators (new life)
-- **[Maintainers](/trinity-and-native-agents/maintainers.md)** — Krishna avatars (preservation & balance)
-- **[Renewers](/trinity-and-native-agents/renewers.md)** — Shiva's fierce forms (renewal through pruning)
-- **[Ainthinai](/trinity-and-native-agents/ainthinai.md)** — Ainthinai Tribal Earth Guardians (local land council)
-
-Please see individual files for contribution guidelines and areas of focus.
+---
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Do these steps **in order** the first time you work on the repo.
 | Tool | Why |
 |------|-----|
 | **Git** | Clone this repository |
-| **Node.js 20+** | Matches [`package.json`](package.json) `engines` and [`.nvmrc`](.nvmrc) |
+| **Node.js 22+** | Matches [`package.json`](package.json) `engines` and [`.nvmrc`](.nvmrc) |
 | **pnpm** | Package manager (`corepack enable` then `corepack prepare pnpm@10.33.0 --activate`, or install pnpm per [pnpm.io](https://pnpm.io/installation)) |
 | **Rust (stable)** + **rustup** | Builds the WASM parser |
 | **wasm-pack** | `cargo install wasm-pack` |

--- a/dx/DEVELOPER_GUIDE.md
+++ b/dx/DEVELOPER_GUIDE.md
@@ -20,7 +20,7 @@ Tamil prosody (யாப்பு) analysis in the browser: **React / TanStack S
 
 ## Testing and coverage
 
-**CI** ([`.github/workflows/ci.yml`](../.github/workflows/ci.yml)): `pnpm run build`, `pnpm run typecheck`, `pnpm run test` (Rust + Vitest). Node version: [`.nvmrc`](../.nvmrc).
+**CI** ([`.github/workflows/ci.yml`](../.github/workflows/ci.yml)): `pnpm run build`, `pnpm run typecheck`, `pnpm run test` (Rust + Vitest). Node version: [`.nvmrc`](../.nvmrc) (currently **22**; `package.json` `engines.node` is `>=22`).
 
 ```bash
 pnpm run test           # Rust + frontend

--- a/dx/DEVELOPER_GUIDE.md
+++ b/dx/DEVELOPER_GUIDE.md
@@ -1,0 +1,132 @@
+# Developer guide
+
+Longer reference for contributors. For a **quick path** from clone to running app (about five minutes), use the root [README.md](../README.md).
+
+---
+
+## What this project is
+
+Tamil prosody (யாப்பு) analysis in the browser: **React / TanStack Start** frontend and a **Rust → WebAssembly** parser (`tamil-seiyul-alagi/`). A rewrite of [Avalokitam](https://github.com/virtualvinodh/avalokitam). Shipped vs planned parser behaviour: [ARCHITECTURE.md](../ARCHITECTURE.md), [tamil-seiyul-alagi/MACHINE_FIRST_SPEC.md](../tamil-seiyul-alagi/MACHINE_FIRST_SPEC.md), [issue #49](https://github.com/p10ns11y/thepulimaangani/issues/49).
+
+---
+
+## Features (summary)
+
+- Syllables as நேர் / நிரை; feet as **Ner/Nirai pattern strings** per linguistic word
+- Metre **hypotheses** (heuristic); linkage structure with line/word positions (classical talai naming is roadmap)
+- JSON export; live parsing in the UI
+
+---
+
+## Testing and coverage
+
+**CI** ([`.github/workflows/ci.yml`](../.github/workflows/ci.yml)): `pnpm run build`, `pnpm run typecheck`, `pnpm run test` (Rust + Vitest). Node version: [`.nvmrc`](../.nvmrc).
+
+```bash
+pnpm run test           # Rust + frontend
+pnpm run test:rust      # Parser only
+pnpm run test:frontend  # Vitest only
+pnpm run typecheck
+```
+
+**Optional Rust line coverage** (requires [cargo-tarpaulin](https://github.com/xd009642/tarpaulin)):
+
+```bash
+cd tamil-seiyul-alagi && cargo tarpaulin
+```
+
+**CRAP-style report** (complexity + coverage, matches CI inputs): prerequisites in [§ CRAP report (local)](#crap-report-local). Then:
+
+```bash
+pnpm run crap:local
+```
+
+Open **`crap-report.md`** at repo root. GitHub Actions job `crap_analysis` uploads artifact **`crap-analysis`**. Parser risk baseline: [`tamil-seiyul-alagi/QUALITY_CRAP_BASELINE.md`](../tamil-seiyul-alagi/QUALITY_CRAP_BASELINE.md).
+
+Coverage expectations: see root [`AGENTS.md`](../AGENTS.md).
+
+`rust-parser-prototype/` is an archived Avalokitam-era prototype; do not extend it.
+
+---
+
+## Architecture
+
+- **Frontend:** TanStack Start, Router, Tailwind — [`src/`](../src/)
+- **Parser:** WASM crate — [`tamil-seiyul-alagi/`](../tamil-seiyul-alagi/)
+- **Flow:** text → `parse_poem_wasm` → JSON → React
+
+Details: [ARCHITECTURE.md](../ARCHITECTURE.md).
+
+---
+
+## CI and deployment
+
+### GitHub Actions
+
+- Workflow runs on `malar` / `main` and on PRs (build, typecheck, test).
+- **CRAP artifact:** job `crap_analysis` → download **`crap-analysis`** → open **`crap-report.md`**.
+
+### CRAP report (local)
+
+Combines Lizard (Rust tree) with `cargo llvm-cov` and Vitest coverage summary → **`crap-report.md`**.
+
+**One-time prerequisites**
+
+- Python 3 + `pip install lizard` (`lizard` on `PATH`)
+- `rustup component add llvm-tools-preview` and `cargo install cargo-llvm-cov`
+
+**Run**
+
+```bash
+pnpm run crap:local
+```
+
+Generated inputs (`lizard-rust.xml`, `tamil-seiyul-alagi/llvm-cov-summary.json`, `coverage/`) are gitignored.
+
+### Vercel (this repo)
+
+Wrong dashboard settings (e.g. output = `dist` only) can yield a **blank page** or **404 on `/`**.
+
+1. **Install** — [`vercel.json`](../vercel.json) `installCommand` runs [`build/ensure-wasm-build-tools.sh`](../build/ensure-wasm-build-tools.sh) (Rust target `wasm32-unknown-unknown`, pinned `wasm-pack`), then `corepack enable` and `pnpm install --frozen-lockfile`. First build can take several minutes.
+
+2. **Build** — `buildCommand`: `NITRO_PRESET=vercel pnpm run build`. That preset writes [Build Output API v3](https://vercel.com/docs/build-output-api/v3) under [`.vercel/output`](../.vercel/output). Local `pnpm run build` without the env still produces `dist/` and `.output/` for preview and tests.
+
+3. **Output directory** — must be **`.vercel/output`**, not `dist` or `dist/client` alone. Server-rendered `/` comes from Nitro, not a static root `index.html` in `dist/`.
+
+4. **Vite** — [`vite.config.ts`](../vite.config.ts): TanStack Start + Nitro; see [TanStack Start on Vercel](https://vercel.com/docs/frameworks/full-stack/tanstack-start).
+
+**Dashboard:** set **Production Branch** to `malar`. PRs get previews; if missing, check Git integration and [deployment protection](https://vercel.com/docs/deployment-protection).
+
+Short summary for agents: [`AGENTS.md`](../AGENTS.md).
+
+### Other hosts
+
+**Cloudflare Pages:** a static `dist` root alone is often insufficient for full-stack TanStack Start; follow current TanStack + Cloudflare docs for routing/workers.
+
+---
+
+## Study materials
+
+[`.grok/study-materials/`](../.grok/study-materials/) — reference prose and research notes.
+
+---
+
+## Using the app (in browser)
+
+1. Open the app (local: `http://localhost:3000` after `pnpm run dev`).
+2. Enter Tamil text or load a sample, parse, inspect syllables/feet/metre hints.
+3. Export JSON or copy results as needed.
+
+---
+
+## Contribution and branches
+
+- **Default branch:** `malar`.
+- **Pick a role/branch:** [trinity-and-native-agents/AGENT_ROLES.md](../trinity-and-native-agents/AGENT_ROLES.md) first; full tables in [creators.md](../trinity-and-native-agents/creators.md), [maintainers.md](../trinity-and-native-agents/maintainers.md), [renewers.md](../trinity-and-native-agents/renewers.md), [ainthinai.md](../trinity-and-native-agents/ainthinai.md).
+- **After merging a PR:** `./dx/syncagents.sh` (use `PUSH=1` to update remote branch tips). [sync-branches-architecture-simple.md](./sync-branches-architecture-simple.md).
+
+---
+
+## License
+
+MIT — see [README.md](../README.md).

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "packageManager": "pnpm@10.33.0",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "imports": {
     "#/*": "./src/*"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- **Root `README.md`** is trimmed to a **quick start** (~5 minutes): prerequisites table, ordered steps (clone → `pnpm install` → `pnpm run dev` → optional typecheck/test), production build one-liner, short deployment pointer, doc index, license.
- **`dx/DEVELOPER_GUIDE.md`** holds the former long README content: project blurb, features, testing/CRAP, architecture pointer, full CI/Vercel section, other hosts, study materials, in-app usage, contribution/sync links.
- **`AGENTS.md`**: Vercel / CI deep link now targets `dx/DEVELOPER_GUIDE.md#ci-and-deployment` instead of a README anchor.

**Follow-up (same branch):** **`package.json` `engines.node`** is **`>=22`**; README prerequisites and developer guide CI note updated for **Node 22** (`.nvmrc` was already `22`).

**Branch:** `iyanar` (DevEx / contributor docs).

**Post-merge:** run `PUSH=1 ./dx/syncagents.sh` if you want all pollinator remotes reset to the new `malar` tip.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a47b2e7d-2ac0-46ad-93c7-c9f880a0c5fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a47b2e7d-2ac0-46ad-93c7-c9f880a0c5fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

