### PR TITLE
feat(dx): syncagents creates local tracking branches for all origin refs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ Thepulimaangani is a Tamil prosody analysis web application with React/TypeScrip
 
 - **Feature branch names:** pick by responsibility — start with [trinity-and-native-agents/AGENT_ROLES.md](trinity-and-native-agents/AGENT_ROLES.md) (one-page quick pick). Full pollinator table: [trinity-and-native-agents/creators.md](trinity-and-native-agents/creators.md). Examples: `pattampoochi` for general frontend/UI, `thithali` for short UI prototypes, `vannathupoochi` for tokens/themes, `thumpi` for AI-heavy or deep architecture, `theni` for parser/core logic.
 
-- **After every PR merge:** from the repo root, run `./dx/syncagents.sh` so local branches stay aligned with `origin/malar` (skips open PR heads and `legacy`). Use `PUSH=1` only when you intend to push updated tips. Details: [dx/sync-branches-architecture-simple.md](dx/sync-branches-architecture-simple.md).
+- **After every PR merge:** from the repo root, run `./dx/syncagents.sh` so local branches stay aligned with `origin/malar` (skips open PR heads and `legacy`). The script creates any **missing local tracking branches** for `origin/*` after fetch, then resets non-default locals to the default branch tip. Use `PUSH=1` only when you intend to push updated tips. Details: [dx/sync-branches-architecture-simple.md](dx/sync-branches-architecture-simple.md).
 
 ## Rules
 - Always run tests and typecheck before/after changes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ Thepulimaangani is a Tamil prosody analysis web application with React/TypeScrip
 
 - **Feature branch names:** pick by responsibility — start with [trinity-and-native-agents/AGENT_ROLES.md](trinity-and-native-agents/AGENT_ROLES.md) (one-page quick pick). Full pollinator table: [trinity-and-native-agents/creators.md](trinity-and-native-agents/creators.md). Examples: `pattampoochi` for general frontend/UI, `thithali` for short UI prototypes, `vannathupoochi` for tokens/themes, `thumpi` for AI-heavy or deep architecture, `theni` for parser/core logic.
 
-- **After every PR merge:** from the repo root, run `./dx/syncagents.sh` so local branches stay aligned with `origin/malar` (skips open PR heads and `legacy`). The script creates any **missing local tracking branches** for `origin/*` after fetch, then resets non-default locals to the default branch tip. Use `PUSH=1` only when you intend to push updated tips. Details: [dx/sync-branches-architecture-simple.md](dx/sync-branches-architecture-simple.md).
+- **After every PR merge:** from the repo root, run `./dx/syncagents.sh` so local branches stay aligned with `origin/malar` (skips open PR heads and `legacy`). The script creates any **missing local tracking branches** for `origin/*` after fetch, then resets non-default locals to the default branch tip. Use `PUSH=1` only when you intend to push updated tips. **Autonomous agents:** read the **Autonomous agents & safety** section in [dx/sync-branches-architecture-simple.md](dx/sync-branches-architecture-simple.md); use **`DRY_RUN=1`** first.
 
 ## Rules
 - Always run tests and typecheck before/after changes

--- a/dx/DEVELOPER_GUIDE.md
+++ b/dx/DEVELOPER_GUIDE.md
@@ -123,7 +123,7 @@ Short summary for agents: [`AGENTS.md`](../AGENTS.md).
 
 - **Default branch:** `malar`.
 - **Pick a role/branch:** [trinity-and-native-agents/AGENT_ROLES.md](../trinity-and-native-agents/AGENT_ROLES.md) first; full tables in [creators.md](../trinity-and-native-agents/creators.md), [maintainers.md](../trinity-and-native-agents/maintainers.md), [renewers.md](../trinity-and-native-agents/renewers.md), [ainthinai.md](../trinity-and-native-agents/ainthinai.md).
-- **After merging a PR:** `./dx/syncagents.sh` (use `PUSH=1` to update remote branch tips). [sync-branches-architecture-simple.md](./sync-branches-architecture-simple.md).
+- **After merging a PR:** `./dx/syncagents.sh` (use `PUSH=1` to update remote branch tips). The script **creates missing local branches** that track `origin/*` after each fetch, so every remote branch gets a local tracking copy before the reset/rebase phase. [sync-branches-architecture-simple.md](./sync-branches-architecture-simple.md).
 
 ---
 

--- a/dx/DEVELOPER_GUIDE.md
+++ b/dx/DEVELOPER_GUIDE.md
@@ -123,7 +123,7 @@ Short summary for agents: [`AGENTS.md`](../AGENTS.md).
 
 - **Default branch:** `malar`.
 - **Pick a role/branch:** [trinity-and-native-agents/AGENT_ROLES.md](../trinity-and-native-agents/AGENT_ROLES.md) first; full tables in [creators.md](../trinity-and-native-agents/creators.md), [maintainers.md](../trinity-and-native-agents/maintainers.md), [renewers.md](../trinity-and-native-agents/renewers.md), [ainthinai.md](../trinity-and-native-agents/ainthinai.md).
-- **After merging a PR:** `./dx/syncagents.sh` (use `PUSH=1` to update remote branch tips). The script **creates missing local branches** that track `origin/*` after each fetch, so every remote branch gets a local tracking copy before the reset/rebase phase. [sync-branches-architecture-simple.md](./sync-branches-architecture-simple.md).
+- **After merging a PR:** `./dx/syncagents.sh` from the repo root (optional `PUSH=1` to push). Creates missing local `origin/*` tracking branches, then hard-resets non-default branches to the default tip (skips open PR heads and `legacy`). **Agents:** read **Autonomous agents & safety** in [sync-branches-architecture-simple.md](./sync-branches-architecture-simple.md); use `DRY_RUN=1` first.
 
 ---
 

--- a/dx/sync-branches-architecture-simple.md
+++ b/dx/sync-branches-architecture-simple.md
@@ -26,6 +26,43 @@ flowchart TD
 
 ---
 
+## Autonomous agents & safety (read before handover)
+
+This flow is **powerful and destructive by design**. Handing `./dx/syncagents.sh` to an autonomous agent without guardrails can create a mess: **lost commits**, **wrong remotes rewritten**, **stash conflicts**, and **silent alignment of every role branch to `malar`**.
+
+### Where the mess comes from
+
+1. **`git reset --hard origin/<default>`** on almost every local branch (except the default branch and `legacy`). Any **local-only commits** on those branches are gone from the ref (they may linger unreachable until GC).
+2. **`ensure_remote_tracking_locals`** creates a local `origin/*` mirror, then the same reset runs on it — so **newly created tracking branches immediately match `malar`**, not “whatever was only on the remote feature tip” unless that tip equals `malar`.
+3. **`PUSH=1`** runs **`git push --force-with-lease`** on **all** non-default branches — this can **rewrite remote history** for every pushed branch if tips diverged.
+4. **Open PR detection** uses **`gh pr list`** for **this repo only**. If `gh` is missing, mis-authenticated, or pointed at the wrong host, the **active PR skip list can be empty** → **every branch including in-flight work gets reset**.
+5. **Dirty working tree** → stash before sync, stash pop after — merge conflicts or partial pops can leave a **dirty or broken tree**.
+6. **`legacy` is skipped** for reset but is still a normal local branch otherwise — do not assume “skip” means “safe to pile WIP there”.
+
+### Guards and flow (recommended for humans and agents)
+
+| Guard | Why |
+|--------|-----|
+| **Run `DRY_RUN=1 ./dx/syncagents.sh` first** | Prints the plan (including `[DRY] Would reset…`) without mutating refs. |
+| **Clean or intentional tree** | Commit or stash WIP *before* sync; avoid running with half-applied merges. |
+| **Verify `gh auth status` and `gh pr list`** | Ensures open PR heads are detected so those branches are **skipped**. |
+| **Open a draft PR before sync** if a branch must survive | Only **open** PR heads are skipped; un-pushed or “no PR” work on a named branch is **not** protected. |
+| **Never set `PUSH=1` unless explicitly requested** | Avoids mass **force-with-lease** to remotes. |
+| **Confirm `origin` and default branch** | Script uses `origin` and `origin/HEAD` (fallback: `malar`). Wrong remote = wrong reset target. |
+| **One agent / one machine per run** | Avoid concurrent syncs on the same clone. |
+| **After merge: pull `malar` normally** | `syncagents` is for **branch-tip alignment**, not a substitute for `git pull` on your current feature branch when you are mid-development. |
+
+### High-level flow (what the script does)
+
+1. **Collect:** `git fetch --all --prune` → **create missing `origin/*` tracking branches locally** → resolve default branch → optionally checkout default and pull → record dirty/clean → list **all local branches** except default + `legacy` → **`gh pr list` (open)** for skip set.
+2. **Plan:** default-branch update; optional stash; for each branch → **skip** if open PR head else **reset** action; cleanup; restore stash; return to original branch.
+3. **Validate:** remote reachable.
+4. **Sync:** execute plan (`reset --hard origin/<default>` per branch); optional **`PUSH=1`** force-with-lease push of all non-default locals.
+
+Treat **`./dx/syncagents.sh`** as a **fleet-wide local branch normalizer**, not a gentle `git pull`. When in doubt, **`DRY_RUN=1`** and human review of the printed plan.
+
+---
+
 ## State Machine Flow
 
 ```

--- a/dx/syncagents.sh
+++ b/dx/syncagents.sh
@@ -31,6 +31,40 @@ MAIN_COMMIT=""
 IS_DIRTY=0
 STASH_NAME=""
 
+# Create a local branch tracking origin/<name> when it exists on the remote but not locally.
+# Without this, sync only touches branches that already exist locally (see AGENTS.md / sync docs).
+ensure_remote_tracking_locals() {
+    echo -e "${C_PHASE1}→ Ensuring local tracking branches for origin/*...${C_RESET}"
+    local created=0
+    while IFS= read -r short; do
+        [ -z "$short" ] && continue
+        [ "$short" = "HEAD" ] && continue
+        if git show-ref --verify --quiet "refs/heads/$short" 2>/dev/null; then
+            continue
+        fi
+        if ! git show-ref --verify --quiet "refs/remotes/origin/$short" 2>/dev/null; then
+            continue
+        fi
+        if [ "$DRY_RUN" = "1" ]; then
+            echo "   [DRY] Would create local branch $short → origin/$short"
+            created=1
+            continue
+        fi
+        if git branch --track "$short" "origin/$short" --quiet 2>/dev/null; then
+            echo "   + $short → origin/$short"
+            created=1
+        fi
+    done < <(
+        git for-each-ref refs/remotes/origin --format='%(refname:short)' |
+            sed 's|^origin/||' |
+            grep -vxF HEAD |
+            sort -u
+    )
+    if [ "$created" = "0" ]; then
+        echo "   (no new local branches needed)"
+    fi
+}
+
 # ==================== PHASE 1: COLLECT (Blue) ====================
 collect_state() {
     echo -e "\n${C_PHASE1}╔════════════════════════════════════════════════════════════╗${C_RESET}"
@@ -42,6 +76,8 @@ collect_state() {
 
     echo -e "${C_PHASE1}→ Fetching latest from remote...${C_RESET}"
     git fetch --all --prune --quiet
+
+    ensure_remote_tracking_locals
 
     if ! MAIN_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@refs/remotes/origin/@@'); then
         for candidate in main master malar; do

--- a/dx/syncagents.sh
+++ b/dx/syncagents.sh
@@ -3,6 +3,15 @@
 # sync-branches.sh — Simple One-Color-Per-Phase Version
 # Clean, consistent, and beautiful
 #
+# ---------------------------------------------------------------------------
+# DANGER / HANDOVER (especially for autonomous agents)
+#
+# This script can DESTROY local git state at scale: every local branch except
+# the default branch and `legacy` is `git reset --hard` to origin/<default>.
+# It may also `git push --force-with-lease` every such branch when PUSH=1.
+# See dx/sync-branches-architecture-simple.md § "Autonomous agents & safety".
+# ---------------------------------------------------------------------------
+#
 
 set -euo pipefail
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`./dx/syncagents.sh` only rebased/resets branches that **already existed locally**, so clones with few local branches never picked up the full set of `origin/*` role branches until someone manually ran `git branch --track`.

## Changes

- **`dx/syncagents.sh`:** After `git fetch --all --prune`, call **`ensure_remote_tracking_locals`**: for each `origin/<name>` (excluding `HEAD`), create **`git branch --track <name> origin/<name>`** when `<name>` does not exist locally yet. Respects **`DRY_RUN=1`**.
- **Banner comment** at top of `syncagents.sh` warning about destructive resets and `PUSH=1`.
- **`dx/sync-branches-architecture-simple.md`:** New section **“Autonomous agents & safety”** — where the flow can create mess (hard reset, mass push, `gh` dependency, stash), **guard table**, and **step-by-step flow** summary.
- **`AGENTS.md`** and **`dx/DEVELOPER_GUIDE.md`:** Point agents at that section and **`DRY_RUN=1`** before running.

## How to verify

```bash
DRY_RUN=1 ./dx/syncagents.sh   # see “Ensuring local tracking branches…” without writes
./dx/syncagents.sh             # full sync (still skips `legacy` and open PR heads)
```

## Handover note

This script is a **fleet-wide local branch normalizer**, not `git pull`. See the doc section for **why autonomous agents need guards** (`gh` auth, open PR detection, `PUSH=1`, stashes).

## Note

Branches with **open PRs** are still skipped for the hard reset to `malar` — so this PR branch stays safe while the PR is open.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c4a323e-a088-4806-83a7-647e7215b0a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c4a323e-a088-4806-83a7-647e7215b0a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

