### PR TITLE
refactor: Tamil-style aciriya WASM keys and parse-features PCA example

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -97,7 +97,7 @@ The WebAssembly parser is built separately and its artifacts are copied to `src/
    - Syllable detection (நேர் / நிரை) per linguistic word
    - **Feet:** one foot per word; `foot_type` is a hyphenated **Ner/Nirai** pattern (not classical தேமா names in JSON)
    - **Metre:** ranked hypotheses; simple heuristics, not full classical rule engines yet
-   - **Linkage:** consecutive feet with line/word positions; **`linkage_type`** = coarse family (Venthalai, Aasiriyathalai, Kalithalai, Vanjithalai) and **`linkage_special_type`** = issue #36 row (e.g. `VencirVenthalai`); `VenTalai` / `Unknown` only for malformed/empty feet
+   - **Linkage:** consecutive feet with line/word positions; **`linkage_type`** = coarse family (Venthalai, Aciriyathalai, Kalithalai, Vanjithalai) and **`linkage_special_type`** = issue #36 row (e.g. `VencirVenthalai`); `VenTalai` / `Unknown` only for malformed/empty feet
 4. **Result Serialization**: `ParseResult` to JSON in the browser
 5. **Display**: React reads JSON via `adaptWasmJsonToParsedPoem`; **`presentation`** from WASM carries Tamil metre / foot / தளை labels (canonical). The app may still map enums locally when `presentation` is absent (older builds).
 

--- a/src/components/prosody/displayLabels.ts
+++ b/src/components/prosody/displayLabels.ts
@@ -1,23 +1,28 @@
 /** Coarse `linkage_type` from WASM (metre-facing family). */
 const linkageTypeMap: Record<string, string> = {
   Venthalai: 'வெண்டளை',
-  Aasiriyathalai: 'ஆசிரியத்தளை',
+  Aciriyathalai: 'ஆசிரியத்தளை',
   Kalithalai: 'கலித்தளை',
   Vanjithalai: 'வஞ்சித்தளை',
   VenTalai: 'வெண்டளை',
+  AciriyaTalai: 'ஆசிரியத்தளை',
+  // Legacy WASM keys (pre–Tamil-style romanization)
+  Aasiriyathalai: 'ஆசிரியத்தளை',
   AsiriyaTalai: 'ஆசிரியத்தளை',
 }
 
 /** Fine `linkage_special_type` from WASM (issue #36 rows). */
 const linkageSpecialMap: Record<string, string> = {
-  NerondriyaAasiriyathalai: 'நேரொன்றிய ஆசிரியத்தளை',
-  NiraiondriyaAasiriyathalai: 'நிரையொன்றிய ஆசிரியத்தளை',
+  NerondriyaAciriyathalai: 'நேரொன்றிய ஆசிரியத்தளை',
+  NiraiondriyaAciriyathalai: 'நிரையொன்றிய ஆசிரியத்தளை',
   IyarcirVenthalai: 'இயற்சீர் வெண்டளை',
   VencirVenthalai: 'வெண்சீர் வெண்டளை',
   Kalithalai: 'கலித்தளை',
   OndriyaVanchithalai: 'ஒன்றிய வஞ்சித்தளை',
   OndrathaVanchithalai: 'ஒன்றாத வஞ்சித்தளை',
   Unknown: '—',
+  NerondriyaAasiriyathalai: 'நேரொன்றிய ஆசிரியத்தளை',
+  NiraiondriyaAasiriyathalai: 'நிரையொன்றிய ஆசிரியத்தளை',
 }
 
 /** Machine `line_class` → Tamil label. Prefer simple transliteration keys; legacy Avalokitam-style keys kept as aliases. */

--- a/tamil-seiyul-alagi/AGENTS.md
+++ b/tamil-seiyul-alagi/AGENTS.md
@@ -19,7 +19,7 @@ Rust WebAssembly parser for high-performance Tamil prosody analysis. Implements 
 
 - **Syllable classification (Ner/Nirai):** Implemented (`syllable_builder`, `syllable`).
 - **Feet:** One foot per **linguistic word**; `foot_type` is a **Ner/Nirai pattern string** (see `foot_pattern.rs`). Tamil classical foot names and தளை strings are built in **`presentation.rs`** and serialized on each **`ParseResult.presentation`** for WASM and other clients.
-- **Linkage (talai):** Consecutive foot pairs with positions; **`linkage_type`** is the coarse family (`Venthalai`, `Aasiriyathalai`, `Kalithalai`, `Vanjithalai`) for metre-facing logic, and **`linkage_special_type`** is the nuanced bond from the issue #36 table (e.g. `VencirVenthalai`). Cir classes use **Maa / Vilam** (1–2 acai) and **Kaai / Kani** (3+). `VenTalai` + `Unknown` special only when a foot has no syllables.
+- **Linkage (talai):** Consecutive foot pairs with positions; **`linkage_type`** is the coarse family (`Venthalai`, `Aciriyathalai`, `Kalithalai`, `Vanjithalai`) for metre-facing logic, and **`linkage_special_type`** is the nuanced bond from the issue #36 table (e.g. `VencirVenthalai`). Cir classes use **Maa / Vilam** (1–2 acai) and **Kaai / Kani** (3+). `VenTalai` + `Unknown` special only when a foot has no syllables. WASM JSON uses Tamil-style romanization (`aciriya…`); legacy `Aasiriy…` / `Asiriya…` keys remain accepted on deserialize.
 - **Metre:** Heuristic hypotheses (`metre.rs`); not full classical constraint sets yet.
 
 Doc drift and cleanup tasks: [GitHub issue #49](https://github.com/p10ns11y/thepulimaangani/issues/49).

--- a/tamil-seiyul-alagi/Cargo.lock
+++ b/tamil-seiyul-alagi/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -35,6 +44,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -55,6 +70,27 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -111,6 +147,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -127,12 +173,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "nalgebra"
+version = "0.33.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d43ddcacf343185dfd6de2ee786d9e8b1c2301622afab66b6c73baf9882abfd"
+dependencies = [
+ "approx",
+ "matrixmultiply",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "simba",
+ "typenum",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -158,6 +258,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,6 +286,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "regex"
@@ -215,6 +327,21 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "same-file"
@@ -275,6 +402,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "simba"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c99284beb21666094ba2b75bbceda012e610f5479dfcc2d6e2426f53197ffd95"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "wide",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -295,6 +435,8 @@ dependencies = [
 name = "thepulimaangani-parser"
 version = "0.1.0"
 dependencies = [
+ "csv",
+ "nalgebra",
  "regex",
  "serde",
  "serde_json",
@@ -323,6 +465,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-ident"
@@ -439,6 +587,16 @@ name = "wasm-bindgen-test-shared"
 version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23cda5ecc67248c48d3e705d3e03e00af905769b78b9d2a1678b663b8b9d4472"
+
+[[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
+]
 
 [[package]]
 name = "winapi-util"

--- a/tamil-seiyul-alagi/Cargo.toml
+++ b/tamil-seiyul-alagi/Cargo.toml
@@ -27,4 +27,6 @@ crate-type = ["cdylib", "rlib"]
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
+csv = "1.3"
+nalgebra = { version = "0.33", default-features = false, features = ["std"] }
 #serde_json = "1.0"

--- a/tamil-seiyul-alagi/MACHINE_FIRST_SPEC.md
+++ b/tamil-seiyul-alagi/MACHINE_FIRST_SPEC.md
@@ -24,7 +24,8 @@ Two strict layers, no leaks:
 Naming policy:
 - Core module names use machine-first English: `linkage.rs` (not `talai.rs`), `foot.rs`, `metre.rs`, `syllable.rs`, etc.
 - Core type names use machine-first English: `LinkageClass`, `FootPattern`, `MetreHypothesis`. Tamil **prose** labels for feet and தளை are **not** in core logic; they are emitted only inside **`ParseResult.presentation`** (see `presentation.rs`).
-- Exception for canonical grammar identifiers: when a concept is a standard classical-grammar term without a clean neutral replacement, keep the canonical term in English-Latin form (e.g., `VenTalai`, `AsiriyaTalai`) inside enum variants while preserving English container names (`LinkageType`).
+- **Romanization:** Prefer Tamil-style keys in JSON and Rust enum variants for ஆசிரிய- words — **`aciriya`** (one *c*, *i* after *c*), not Sanskrit-style **`asiriya`**. Example WASM strings: `Aciriyathalai`, `AciriyaTalai`, `Aciriyappaa`, `NerondriyaAciriyathalai`. Legacy spellings (`Aasiriy…`, `Asiriya…`, `Asiriyappaa`) remain accepted on deserialize via `serde` aliases.
+- Exception for other canonical grammar identifiers: when there is no clean neutral replacement, keep the established Latin key (e.g. `VenTalai`) inside enum variants while preserving English container names (`LinkageType`).
 
 ---
 
@@ -53,7 +54,7 @@ The registry lives in code as a single typed enum (later phase), with a docstrin
 Conceptual shape (final Rust types refined later):
 
 - `ProsodicUnit` — atomic segmental unit (vowel, consonant, uyirmei, etc.).
-- `Asai` — prosodic metreme. Variants: `Ner`, `Nirai`, plus future `NerPu`, `NiraiPu` if needed.
+- `Acai` — prosodic metreme (Tamil அசை). Variants: `Ner`, `Nirai`, plus future `NerPu`, `NiraiPu` if needed.
 - `FootCandidate` — a span of asai forming a possible foot. Carries `signature`, `width`, `feature_vector`, `score`, `rule_ids`.
 - `LinkageCandidate` — adjacency between two `FootCandidate`s. Carries `class_id`, `is_valid`, `violations`, `score`, `rule_ids`.
 - `MetreHypothesis` — a global interpretation. Carries `metre_id`, `aggregate_score`, `violations`, `rule_ids`, `selected_foot_path`, `selected_linkage_path`.
@@ -74,7 +75,7 @@ Conceptual shape (final Rust types refined later):
 
 Algorithm (lattice-based segmentation):
 
-1. Accept `[Asai]` for a line.
+1. Accept `[Acai]` for a line.
 2. Enumerate candidate foot spans of allowed widths (start with 2..=4 asai).
 3. For each span:
    - Compute `pattern_signature` (asai-type sequence).
@@ -89,7 +90,7 @@ Out-of-scope here: classical foot naming. That mapping lives in `presentation.rs
 
 Module: [`src/linkage.rs`](src/linkage.rs) (successor to the historical `talai` naming).
 
-**Current shipped code** (`linkage.rs`) classifies each consecutive pair using the **previous foot’s last acai** (Maa/Vilam for 1–2 acai per foot, Kaai/Kani for 3+) and the **next foot’s first acai** (Ner/Nirai). JSON exposes **`linkage_type`** (coarse: `Venthalai`, `Aasiriyathalai`, `Kalithalai`, `Vanjithalai`) and **`linkage_special_type`** (e.g. `VencirVenthalai`, `NerondriyaAasiriyathalai`). The lattice wording below remains the **target** once `FootCandidate` paths exist.
+**Current shipped code** (`linkage.rs`) classifies each consecutive pair using the **previous foot’s last acai** (Maa/Vilam for 1–2 acai per foot, Kaai/Kani for 3+) and the **next foot’s first acai** (Ner/Nirai). JSON exposes **`linkage_type`** (coarse: `Venthalai`, `Aciriyathalai`, `Kalithalai`, `Vanjithalai`) and **`linkage_special_type`** (e.g. `VencirVenthalai`, `NerondriyaAciriyathalai`). The lattice wording below remains the **target** once `FootCandidate` paths exist.
 
 Algorithm:
 

--- a/tamil-seiyul-alagi/QUALITY_CRAP_BASELINE.md
+++ b/tamil-seiyul-alagi/QUALITY_CRAP_BASELINE.md
@@ -38,7 +38,7 @@ Interpretation:
 
 | Module / Function | Complexity Rank | Untested Rank | Score | Risk | Why |
 |---|---:|---:|---:|---|---|
-| `src/metre.rs::detect_metre` | 3 | 3 | 9 | critical | Heuristic still misclassifies known Asiriyappaa fixture; metre hypotheses naive. _(Unchanged in recent work.)_ |
+| `src/metre.rs::detect_metre` | 3 | 3 | 9 | critical | Heuristic still misclassifies known Aciriyappaa fixture; metre hypotheses naive. _(Unchanged in recent work.)_ |
 | `src/lib.rs::parse_poem` | 3 | 2 | 6 | high | Main integration seam. **Mitigated:** direct unit tests for `types::flat_lines_from_poem` (linguistic_words vs words vs empty) reduce untested surface between tree and legacy `lines`. |
 | `src/syllable_builder.rs::build_inner` | 2 | 2 | 4 | moderate | Ordered regex scan per **linguistic word**; unit tests cover common paths. |
 | `src/word_scope.rs::segment_syllables_from_normalized` | 2 | 2 | 4 | moderate | Line/word tokenization drives all downstream syllables; integration-heavy. |

--- a/tamil-seiyul-alagi/examples/parse_features_pca_metre.rs
+++ b/tamil-seiyul-alagi/examples/parse_features_pca_metre.rs
@@ -1,0 +1,164 @@
+//! PCA on `dense_*` columns of `data/training/poem_variations_training.csv` (dev-only).
+//!
+//! Regenerates the CSV with `cargo run --example export_poem_variations_training_csv` when that
+//! example exists; otherwise pass an explicit path:
+//!
+//! ```text
+//! cargo run --example parse_features_pca_metre -- ../data/training/poem_variations_training.csv
+//! ```
+
+use std::path::Path;
+
+use nalgebra::{DMatrix, DVector};
+
+const D: usize = 51;
+
+fn metre_index(s: &str) -> Option<usize> {
+    let t = s.trim().to_ascii_lowercase();
+    match t.as_str() {
+        "venpaa" => Some(0),
+        "aciriyappa" => Some(1),
+        "kalippaa" => Some(2),
+        "vanjippaa" => Some(3),
+        _ => None,
+    }
+}
+
+fn read_matrix(path: &Path) -> Result<(DMatrix<f64>, DVector<f64>), Box<dyn std::error::Error>> {
+    let mut rdr = csv::Reader::from_path(path)?;
+    let headers = rdr.headers()?.clone();
+    let mut dense_start: Option<usize> = None;
+    for (i, h) in headers.iter().enumerate() {
+        if h == "dense_0" {
+            dense_start = Some(i);
+            break;
+        }
+    }
+    let d0 = dense_start.ok_or("missing dense_0 column (export training CSV first)")?;
+
+    let mut rows: Vec<f64> = Vec::new();
+    let mut y: Vec<f64> = Vec::new();
+    for rec in rdr.records() {
+        let rec = rec?;
+        let parent = rec
+            .get(
+                headers
+                    .iter()
+                    .position(|h| h == "parent_metre")
+                    .ok_or("missing parent_metre")?,
+            )
+            .unwrap_or("");
+        let Some(yi) = metre_index(parent).map(|k| k as f64) else {
+            continue;
+        };
+        let parse_ok = rec
+            .get(
+                headers
+                    .iter()
+                    .position(|h| h == "parse_ok")
+                    .ok_or("missing parse_ok")?,
+            )
+            .unwrap_or("0");
+        if parse_ok != "1" {
+            continue;
+        }
+        for j in 0..D {
+            let v: f64 = rec
+                .get(d0 + j)
+                .ok_or_else(|| format!("short row at dense_{j}"))?
+                .parse()?;
+            rows.push(v);
+        }
+        y.push(yi);
+    }
+    let n = y.len();
+    if n < 5 {
+        return Err("need at least 5 parse_ok rows with known parent_metre".into());
+    }
+    let x = DMatrix::from_row_slice(n, D, &rows);
+    let yv = DVector::from_vec(y);
+    Ok((x, yv))
+}
+
+fn column_means(x: &DMatrix<f64>) -> DVector<f64> {
+    let mut m = DVector::zeros(x.ncols());
+    for j in 0..x.ncols() {
+        let mut s = 0.0;
+        for i in 0..x.nrows() {
+            s += x[(i, j)];
+        }
+        m[j] = s / x.nrows() as f64;
+    }
+    m
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let path = std::env::args()
+        .nth(1)
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| {
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("../data/training/poem_variations_training.csv")
+        });
+    if !path.exists() {
+        eprintln!(
+            "Missing {}. Generate with the training CSV export example if available.",
+            path.display()
+        );
+        return Ok(());
+    }
+
+    let (x, y) = read_matrix(&path)?;
+    let n = x.nrows();
+    let means = column_means(&x);
+    let mut xc = x.clone();
+    for j in 0..D {
+        for i in 0..n {
+            xc[(i, j)] -= means[j];
+        }
+    }
+
+    // Thin SVD: X = U Σ V^T ; V's first column = first PC loadings (feature weights).
+    let svd = nalgebra::linalg::SVD::new(xc, true, true);
+    let vt = svd.v_t.ok_or("SVD did not return V^T")?;
+    let pc1: Vec<f64> = (0..D).map(|j| vt[(0, j)]).collect();
+
+    let y_mean: f64 = y.iter().sum::<f64>() / y.len() as f64;
+    let yc: DVector<f64> = y.map(|v| v - y_mean);
+    let mut s_xy = vec![0.0f64; D];
+    let mut s_xx = vec![0.0f64; D];
+    for j in 0..D {
+        for i in 0..n {
+            let xv = x[(i, j)] - means[j];
+            s_xy[j] += xv * yc[i];
+            s_xx[j] += xv * xv;
+        }
+    }
+    let mut corr_feat: Vec<(usize, f64)> = (0..D)
+        .map(|j| {
+            let den = (s_xx[j] * yc.dot(&yc)).sqrt().max(1e-12);
+            (j, s_xy[j] / den)
+        })
+        .collect();
+    corr_feat.sort_by(|a, b| b.1.abs().partial_cmp(&a.1.abs()).unwrap());
+
+    let mut pc1_rank: Vec<(usize, f64)> = (0..D).map(|j| (j, pc1[j])).collect();
+    pc1_rank.sort_by(|a, b| b.1.abs().partial_cmp(&a.1.abs()).unwrap());
+
+    println!("{{");
+    println!("  \"csv\": {:?},", path.to_string_lossy());
+    println!("  \"n_rows\": {n},");
+    println!("  \"singular_value_0\": {:?},", svd.singular_values.get(0).copied());
+    println!("  \"note\": \"PC1 loadings are orthogonal directions in feature space; |corr(dense_j, metre_index)| is a simpler linear association with coarse parent_metre.\",");
+    println!("  \"top_pc1_abs_loadings\": [");
+    for (j, v) in pc1_rank.iter().take(12) {
+        println!("    {{ \"dense_index\": {j}, \"pc1_loading\": {v} }},");
+    }
+    println!("  ],");
+    println!("  \"top_abs_correlation_with_metre_index\": [");
+    for (j, v) in corr_feat.iter().take(12) {
+        println!("    {{ \"dense_index\": {j}, \"corr\": {v} }},");
+    }
+    println!("  ]");
+    println!("}}");
+    Ok(())
+}

--- a/tamil-seiyul-alagi/src/linkage.rs
+++ b/tamil-seiyul-alagi/src/linkage.rs
@@ -21,20 +21,25 @@ pub enum CirAcaiClass {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum LinkageType {
     Venthalai,
-    Aasiriyathalai,
+    /// Coarse ஆசிரியத்தளை family (JSON: `Aciriyathalai`; legacy `Aasiriyathalai` accepted on deserialize).
+    #[serde(rename = "Aciriyathalai", alias = "Aasiriyathalai")]
+    Aciriyathalai,
     Kalithalai,
     Vanjithalai,
     /// Reserved when the previous foot’s last cir cannot be classified (e.g. empty foot).
     VenTalai,
-    AsiriyaTalai,
+    #[serde(rename = "AciriyaTalai", alias = "AsiriyaTalai")]
+    AciriyaTalai,
     Other(String),
 }
 
 /// Nuanced bond name within a [`LinkageType`] family (issue #36 row names).
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub enum LinkageSpecialType {
-    NerondriyaAasiriyathalai,
-    NiraiondriyaAasiriyathalai,
+    #[serde(rename = "NerondriyaAciriyathalai", alias = "NerondriyaAasiriyathalai")]
+    NerondriyaAciriyathalai,
+    #[serde(rename = "NiraiondriyaAciriyathalai", alias = "NiraiondriyaAasiriyathalai")]
+    NiraiondriyaAciriyathalai,
     IyarcirVenthalai,
     VencirVenthalai,
     Kalithalai,
@@ -121,12 +126,12 @@ fn classify_edge(
 ) -> (LinkageType, LinkageSpecialType) {
     match (prev_cir, next_first) {
         (CirAcaiClass::Maa, SyllableType::Ner) => (
-            LinkageType::Aasiriyathalai,
-            LinkageSpecialType::NerondriyaAasiriyathalai,
+            LinkageType::Aciriyathalai,
+            LinkageSpecialType::NerondriyaAciriyathalai,
         ),
         (CirAcaiClass::Vilam, SyllableType::Nirai) => (
-            LinkageType::Aasiriyathalai,
-            LinkageSpecialType::NiraiondriyaAasiriyathalai,
+            LinkageType::Aciriyathalai,
+            LinkageSpecialType::NiraiondriyaAciriyathalai,
         ),
         (CirAcaiClass::Maa, SyllableType::Nirai) => (
             LinkageType::Venthalai,
@@ -245,28 +250,28 @@ mod tests {
     }
 
     #[test]
-    fn table_maa_ner_is_nerondriya_aasiriyathalai() {
+    fn table_maa_ner_is_nerondriya_aciriyathalai() {
         let feet = vec![foot_with(&[SyllableType::Ner]), foot_with(&[SyllableType::Ner])];
         let pos = positions(2);
         let l = analyze_linkage(&pos, &feet);
         assert_eq!(l.len(), 1);
-        assert_eq!(l[0].linkage_type, LinkageType::Aasiriyathalai);
+        assert_eq!(l[0].linkage_type, LinkageType::Aciriyathalai);
         assert_eq!(
             l[0].linkage_special_type,
-            LinkageSpecialType::NerondriyaAasiriyathalai
+            LinkageSpecialType::NerondriyaAciriyathalai
         );
         assert!(l[0].is_valid);
     }
 
     #[test]
-    fn table_vilam_nirai_is_niraiondriya_aasiriyathalai() {
+    fn table_vilam_nirai_is_niraiondriya_aciriyathalai() {
         let feet = vec![foot_with(&[SyllableType::Nirai]), foot_with(&[SyllableType::Nirai])];
         let pos = positions(2);
         let l = analyze_linkage(&pos, &feet);
-        assert_eq!(l[0].linkage_type, LinkageType::Aasiriyathalai);
+        assert_eq!(l[0].linkage_type, LinkageType::Aciriyathalai);
         assert_eq!(
             l[0].linkage_special_type,
-            LinkageSpecialType::NiraiondriyaAasiriyathalai
+            LinkageSpecialType::NiraiondriyaAciriyathalai
         );
     }
 
@@ -364,6 +369,26 @@ mod tests {
         assert_eq!(
             l[0].linkage_special_type,
             LinkageSpecialType::OndrathaVanchithalai
+        );
+    }
+
+    #[test]
+    fn serde_accepts_legacy_aciriya_spellings_in_json() {
+        assert_eq!(
+            serde_json::from_str::<LinkageType>("\"Aasiriyathalai\"").unwrap(),
+            LinkageType::Aciriyathalai
+        );
+        assert_eq!(
+            serde_json::from_str::<LinkageType>("\"AsiriyaTalai\"").unwrap(),
+            LinkageType::AciriyaTalai
+        );
+        assert_eq!(
+            serde_json::from_str::<LinkageSpecialType>("\"NerondriyaAasiriyathalai\"").unwrap(),
+            LinkageSpecialType::NerondriyaAciriyathalai
+        );
+        assert_eq!(
+            serde_json::from_str::<crate::metre::MetreType>("\"Asiriyappaa\"").unwrap(),
+            crate::metre::MetreType::Aciriyappaa
         );
     }
 

--- a/tamil-seiyul-alagi/src/metre.rs
+++ b/tamil-seiyul-alagi/src/metre.rs
@@ -7,7 +7,9 @@ use crate::types::{MetreHypothesis, RuleId};
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum MetreType {
     Venpaa,
-    Asiriyappaa,
+    /// ஆசிரியப்பா — WASM/JSON key uses Tamil-style romanization (`aciriya`), not Sanskrit-style `asiriya`.
+    #[serde(rename = "Aciriyappaa", alias = "Asiriyappaa")]
+    Aciriyappaa,
     Kalippaa,
     Vanjippaa,
     Other(String),
@@ -21,7 +23,7 @@ pub fn detect_metre(feet: &[Foot], _linkage: &[Linkage], no_detect: bool) -> Opt
     if feet.len() >= 4 {
         Some(MetreType::Venpaa)
     } else {
-        Some(MetreType::Asiriyappaa)
+        Some(MetreType::Aciriyappaa)
     }
 }
 

--- a/tamil-seiyul-alagi/src/poem_variations.rs
+++ b/tamil-seiyul-alagi/src/poem_variations.rs
@@ -480,7 +480,7 @@ static VANJIPPAA_VARIATIONS: &[PoemVariationRow] = &[
     },
 ];
 
-/// All four metre blocks in stable order: Venpaa, Asiriyappa, Kalippaa, Vanjippaa.
+/// All four metre blocks in stable order: Venpaa, Aciriyappa, Kalippaa, Vanjippaa.
 pub fn poem_variations_blocks() -> [PoemVariationsBlock; 4] {
     [
         PoemVariationsBlock {

--- a/tamil-seiyul-alagi/src/presentation.rs
+++ b/tamil-seiyul-alagi/src/presentation.rs
@@ -62,7 +62,7 @@ pub fn to_display(
 fn format_metre(metre: &MetreType) -> String {
     match metre {
         MetreType::Venpaa => "வெண்பா".to_string(),
-        MetreType::Asiriyappaa => "ஆசிரியப்பா".to_string(),
+        MetreType::Aciriyappaa => "ஆசிரியப்பா".to_string(),
         MetreType::Kalippaa => "கலிப்பா".to_string(),
         MetreType::Vanjippaa => "வஞ்சிப்பா".to_string(),
         MetreType::Other(s) => s.clone(),
@@ -136,8 +136,8 @@ pub fn foot_pattern_display(pattern: &str) -> String {
 
 fn to_display_talai(t: &Linkage) -> DisplayTalai {
     let talai_type = match t.linkage_special_type {
-        LinkageSpecialType::NerondriyaAasiriyathalai => "நேரொன்றிய ஆசிரியத்தளை".to_string(),
-        LinkageSpecialType::NiraiondriyaAasiriyathalai => {
+        LinkageSpecialType::NerondriyaAciriyathalai => "நேரொன்றிய ஆசிரியத்தளை".to_string(),
+        LinkageSpecialType::NiraiondriyaAciriyathalai => {
             "நிரையொன்றிய ஆசிரியத்தளை".to_string()
         }
         LinkageSpecialType::IyarcirVenthalai => "இயற்சீர் வெண்டளை".to_string(),
@@ -147,9 +147,9 @@ fn to_display_talai(t: &Linkage) -> DisplayTalai {
         LinkageSpecialType::OndrathaVanchithalai => "ஒன்றாத வஞ்சித்தளை".to_string(),
         LinkageSpecialType::Unknown => match &t.linkage_type {
             LinkageType::VenTalai => "வெண்டளை".to_string(),
-            LinkageType::AsiriyaTalai => "ஆசிரியத்தளை".to_string(),
+            LinkageType::AciriyaTalai => "ஆசிரியத்தளை".to_string(),
             LinkageType::Venthalai => "வெண்டளை".to_string(),
-            LinkageType::Aasiriyathalai => "ஆசிரியத்தளை".to_string(),
+            LinkageType::Aciriyathalai => "ஆசிரியத்தளை".to_string(),
             LinkageType::Kalithalai => "கலித்தளை".to_string(),
             LinkageType::Vanjithalai => "வஞ்சித்தளை".to_string(),
             LinkageType::Other(s) => s.clone(),

--- a/tamil-seiyul-alagi/tests/test_poem_variations.rs
+++ b/tamil-seiyul-alagi/tests/test_poem_variations.rs
@@ -40,12 +40,12 @@ fn test_venpaa_variations() {
 }
 
 #[test]
-#[ignore = "Metre hint: parser currently classifies sample as Venpaa; Asiriyappaa expectation needs parser/metre alignment (run with cargo test --test test_poem_variations -- --ignored)"]
+#[ignore = "Metre hint: parser currently classifies sample as Venpaa; Aciriyappaa expectation needs parser/metre alignment (run with cargo test --test test_poem_variations -- --ignored)"]
 fn test_aciriyappa_variations() {
     let (special, _) = poem_variations_for_metre(ACIRIYAPPA).expect("aciriyappa block");
-    // First two classical Asiriyappaa forms (third is nilaimandila — longer sample).
+    // First two classical Aciriyappaa forms (third is nilaimandila — longer sample).
     for row in special.iter().take(2) {
-        assert_parses_successfully(row.example, Some("Asiriyappaa"));
+        assert_parses_successfully(row.example, Some("Aciriyappaa"));
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Standardizes **Tamil-style romanization** for ஆசிரிய- concepts in **WASM/JSON** and Rust: **`aciriya`** (one `c`, `i` after `c`) instead of mixed **`asiriya`** / **`aasiriya`** spellings.

## Code

- **`MetreType`:** `Aciriyappaa` with `serde(rename = "Aciriyappaa", alias = "Asiriyappaa")` so new JSON uses the canonical key while old snapshots still deserialize.
- **`LinkageType` / `LinkageSpecialType`:** `Aciriyathalai`, `AciriyaTalai`, `NerondriyaAciriyathalai`, `NiraiondriyaAciriyathalai` with aliases for legacy strings.
- **`presentation.rs`:** match arms updated.
- **Frontend** `displayLabels.ts`: primary keys use `Aciriya*`; legacy keys kept as duplicates for older WASM artifacts.
- **Unit test** `serde_accepts_legacy_aciriya_spellings_in_json` locks in backward-compatible deserialization.

## Docs

- `tamil-seiyul-alagi/AGENTS.md`, `MACHINE_FIRST_SPEC.md` (including `Acai` wording for metremes), `ARCHITECTURE.md`, `QUALITY_CRAP_BASELINE.md` updated to the new JSON spellings.

## PCA (dev)

- Example `parse_features_pca_metre` reads `data/training/poem_variations_training.csv` (when present), runs centered thin SVD for **PC1 loadings**, and prints **|corr(dense_j, coarse metre index)|** as a simpler linear hint. Dev-deps: `csv`, `nalgebra` (not in the WASM lib path).

## Tests

- `cargo test` in `tamil-seiyul-alagi` — all green (43 lib + 5 integration; 1 ignored metre test unchanged in behavior).

## Follow-ups (not in this PR)

- `.grok/`, `.kilo/`, `rust-parser-prototype/` still contain older spellings in study notes; can normalize in a separate doc-only pass if desired.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4866ed28-50d8-4520-87ce-6730f3e3ce01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4866ed28-50d8-4520-87ce-6730f3e3ce01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

