### PR TITLE
fix: live preview feet layout with blank stanza lines

### DIFF
--- a/src/lib/__tests__/livePreviewEditScenarios.test.ts
+++ b/src/lib/__tests__/livePreviewEditScenarios.test.ts
@@ -142,9 +142,23 @@ describe.skipIf(!isWasmPkgBuilt())('live preview + WASM integration', () => {
           `step ${step}: aligned layout should surface syllables`,
         ).toBeGreaterThan(0)
       } else {
+        // Editor can show extra blank-only rows (e.g. reversed lines leave `''` first; WASM
+        // `normalize_text` trims the whole poem). `feetPerPhysicalLine` may merge those blanks
+        // into buckets — then counts differ but chips stay aligned. Otherwise require empty rows
+        // so we never slice feet onto wrong lines (e.g. mid-edit stale parse).
+        const totalBucket = totalSyllablesFromBuckets(buckets)
+        const allEmpty = buckets.every((r) => r.length === 0)
+        const maxRowSyllables = Math.max(
+          ...buckets.map((row) => flattenFootSyllableTexts(row).length),
+          0,
+        )
+        const mergedAligned =
+          totalBucket === parsed.syllables.length &&
+          totalBucket > 0 &&
+          (phys.length < 2 || maxRowSyllables < parsed.syllables.length)
         expect(
-          buckets.every((r) => r.length === 0),
-          `step ${step}: mismatched counts should avoid placing feet on wrong rows`,
+          allEmpty || mergedAligned,
+          `step ${step}: mismatched counts should either empty chips or fully partition syllables without one row holding the whole poem`,
         ).toBe(true)
       }
     }

--- a/src/lib/__tests__/parserFeetLayout.test.ts
+++ b/src/lib/__tests__/parserFeetLayout.test.ts
@@ -43,6 +43,54 @@ describe('feetPerPhysicalLine', () => {
     expect(buckets[0]).toEqual([])
     expect(buckets[1]).toEqual([])
   })
+
+  it('keeps structured feet aligned when blank stanza lines sit between Tamil rows', () => {
+    const poemText = 'கற்றது\n\nமொழிந்தது'
+    const lines: ParsedPoem['lines'] = [
+      {
+        line_class: '—',
+        feet: [
+          {
+            foot_type: 'Ner-Nirai',
+            syllables: [
+              { text: 'கற்', syllable_type: 'Ner' },
+              { text: 'றது', syllable_type: 'Nirai' },
+            ],
+          },
+        ],
+      },
+      {
+        line_class: '—',
+        feet: [{ foot_type: 'Ner', syllables: [{ text: 'மொழிந்தது', syllable_type: 'Ner' }] }],
+      },
+    ]
+    const buckets = feetPerPhysicalLine(poem(lines), poemText)
+    expect(buckets).toHaveLength(3)
+    expect(buckets[0]!.length).toBe(1)
+    expect(buckets[1]).toEqual([])
+    expect(buckets[2]!.length).toBe(1)
+    expect(buckets[2]![0]!.syllables[0]!.text).toBe('மொழிந்தது')
+  })
+
+  it('handles two consecutive blank stanza separators between Tamil rows', () => {
+    const poemText = 'கற்றது\n\n\nமொழிந்தது'
+    const lines: ParsedPoem['lines'] = [
+      {
+        line_class: '—',
+        feet: [{ foot_type: 'Ner', syllables: [{ text: 'கற்றது', syllable_type: 'Ner' }] }],
+      },
+      {
+        line_class: '—',
+        feet: [{ foot_type: 'Ner', syllables: [{ text: 'மொழிந்தது', syllable_type: 'Ner' }] }],
+      },
+    ]
+    const buckets = feetPerPhysicalLine(poem(lines), poemText)
+    expect(buckets).toHaveLength(4)
+    expect(buckets[0]!.length).toBe(1)
+    expect(buckets[1]).toEqual([])
+    expect(buckets[2]).toEqual([])
+    expect(buckets[3]!.length).toBe(1)
+  })
 })
 
 describe('groupsFromFeet', () => {

--- a/src/lib/parserFeetLayout.ts
+++ b/src/lib/parserFeetLayout.ts
@@ -2,10 +2,75 @@ import type { ParsedFoot, ParsedPoem } from '#/types/parsedPoem'
 
 import { physicalPoemLines } from '#/lib/mapFeetToPhysicalLines'
 
+const TAMIL_BLOCK = /[\u0B80-\u0BFF]/
+
+function lineContainsTamil(line: string): boolean {
+  return TAMIL_BLOCK.test(line)
+}
+
+function isBlankOnlyLine(line: string): boolean {
+  return line.trim().length === 0
+}
+
+function prevNonBlankLineIndex(physical: string[], from: number): number {
+  for (let j = from - 1; j >= 0; j--) {
+    if (!isBlankOnlyLine(physical[j]!)) return j
+  }
+  return -1
+}
+
+function nextNonBlankLineIndex(physical: string[], from: number): number {
+  for (let j = from + 1; j < physical.length; j++) {
+    if (!isBlankOnlyLine(physical[j]!)) return j
+  }
+  return physical.length
+}
+
 /**
- * Feet per physical editor line: use WASM `parsed.lines` only when line counts match.
- * On mismatch (mid-edit before debounced parse returns), return **empty** feet per line so we never
- * slice parser feet onto wrong rows (the old character-weight fallback caused bleed-over).
+ * WASM `parsed.lines` omits blank-only physical rows (Rust `lines()` skips empty lines). The editor
+ * still shows those rows, so merge: insert empty `feet` buckets for stanza-gap blanks **between**
+ * two Tamil-bearing lines without consuming a parser line.
+ */
+function mergeFeetBucketsForBlankStanzaLines(
+  physical: string[],
+  structuredFeet: ParsedFoot[][],
+): ParsedFoot[][] | null {
+  const nPhys = physical.length
+  const nStruct = structuredFeet.length
+  if (nStruct === 0 || nPhys < nStruct) return null
+  if (nPhys === nStruct) return structuredFeet
+
+  const out: ParsedFoot[][] = []
+  let si = 0
+
+  for (let pi = 0; pi < nPhys; pi++) {
+    const line = physical[pi] ?? ''
+    if (isBlankOnlyLine(line)) {
+      const prevI = prevNonBlankLineIndex(physical, pi)
+      const nextI = nextNonBlankLineIndex(physical, pi)
+      const prevTamil = prevI >= 0 && lineContainsTamil(physical[prevI]!)
+      const nextTamil = nextI < nPhys && lineContainsTamil(physical[nextI]!)
+      // Stanza gap (between Tamil blocks) or leading blank before the first Tamil line — WASM
+      // `lines()` can omit those empty physical rows.
+      if (nextTamil && (prevTamil || prevI < 0)) {
+        out.push([])
+        continue
+      }
+    }
+
+    if (si >= structuredFeet.length) return null
+    out.push(structuredFeet[si]!)
+    si += 1
+  }
+
+  return si === structuredFeet.length ? out : null
+}
+
+/**
+ * Feet per physical editor line: use WASM `parsed.lines` when line counts match, or when the only
+ * extra physical rows are blank stanza separators between Tamil lines (WASM omits those lines).
+ * On other mismatches (mid-edit before debounced parse returns), return **empty** feet per line so
+ * we never slice parser feet onto wrong rows (the old character-weight fallback caused bleed-over).
  */
 export function feetPerPhysicalLine(parsed: ParsedPoem | null, poemText: string): ParsedFoot[][] {
   const physical = physicalPoemLines(poemText)
@@ -16,8 +81,10 @@ export function feetPerPhysicalLine(parsed: ParsedPoem | null, poemText: string)
     return structured.map((ln) => ln.feet)
   }
 
-  // Editor line count ≠ parser snapshot (mid-edit debounce, trailing newline drift before fix, etc.).
-  // Do **not** use character-weight `mapFeetToPhysicalLines` — it slices feet across wrong rows.
+  const structuredFeet = structured.map((ln) => ln.feet)
+  const merged = mergeFeetBucketsForBlankStanzaLines(physical, structuredFeet)
+  if (merged) return merged
+
   return physical.map(() => [])
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Live syllable preview maps WASM `parsed.lines` onto editor physical lines only when **line counts match** (`feetPerPhysicalLine`). The Rust pipeline builds `ParseResult.lines` from `str::lines()`, which **drops blank-only rows**. The editor still shows blank lines between stanzas, so `physicalPoemLines(text).length` was greater than `parsed.lines.length`. On that mismatch the UI deliberately returned **empty feet for every line** (safer than the old character-weight slicer), which looked like “prosody not working” especially in live mode.

## Fix

When counts differ, detect **blank-only** physical lines that sit between (or before) **Tamil-bearing** lines and insert empty `feet` buckets for those rows without advancing the structured line index. Any other mismatch still falls back to empty feet per line.

## Tests

- Vitest cases in `parserFeetLayout.test.ts` for one and two consecutive blank separators between Tamil lines.
- `livePreviewEditScenarios` aggressive-edit sequence updated: reversed lines can leave a leading blank while WASM trims the whole poem — counts differ but merge aligns chips; the test now accepts either all-empty buckets or a full syllable partition without “whole poem on row 0”.

## Files

- `src/lib/parserFeetLayout.ts` — merge logic
- `src/lib/__tests__/parserFeetLayout.test.ts` — regression tests
- `src/lib/__tests__/livePreviewEditScenarios.test.ts` — relaxed mismatch assertion for merged layout
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1c88628b-ca20-4fcd-a874-034dbc934e96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c88628b-ca20-4fcd-a874-034dbc934e96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

