### PR TITLE
ci: pin GitHub Actions to latest stable SHA commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,10 @@ jobs:
           pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Rust (wasm32)
-        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # stable
         with:
+          # Required when the action is SHA-pinned (ref name is not "stable").
+          toolchain: stable
           targets: wasm32-unknown-unknown
 
       - name: Rust dependency cache
@@ -71,8 +73,10 @@ jobs:
           pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Rust (llvm-cov + wasm32 for build:wasm)
-        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # stable
         with:
+          # Required when the action is SHA-pinned (ref name is not "stable").
+          toolchain: stable
           components: llvm-tools-preview
           targets: wasm32-unknown-unknown
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
     timeout-minutes: 35
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f # v7.0.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@363be39a57dfa5801e05c6e0c549d622a376cf15 # v7.0.0
         with:
           node-version-file: .nvmrc
           package-manager-cache: false
@@ -31,17 +31,17 @@ jobs:
           pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Rust (wasm32)
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88
         with:
           targets: wasm32-unknown-unknown
 
       - name: Rust dependency cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        uses: Swatinem/rust-cache@7e35be21c2b94d972b1143087fabc27d7dc881ef
         with:
           workspaces: tamil-seiyul-alagi
 
       - name: wasm-pack
-        uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # latest
+        uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 # v2.83.2
         with:
           tool: wasm-pack@0.13.1
 
@@ -56,10 +56,10 @@ jobs:
     timeout-minutes: 40
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f # v7.0.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@363be39a57dfa5801e05c6e0c549d622a376cf15 # v7.0.0
         with:
           node-version-file: .nvmrc
           package-manager-cache: false
@@ -71,23 +71,23 @@ jobs:
           pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Rust (llvm-cov + wasm32 for build:wasm)
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88
         with:
           components: llvm-tools-preview
           targets: wasm32-unknown-unknown
 
       - name: Rust dependency cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        uses: Swatinem/rust-cache@7e35be21c2b94d972b1143087fabc27d7dc881ef
         with:
           workspaces: tamil-seiyul-alagi
 
       - name: wasm-pack
-        uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # latest
+        uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 # v2.83.2
         with:
           tool: wasm-pack@0.13.1
 
       - name: cargo-llvm-cov
-        uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # latest
+        uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 # v2.83.2
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` from v6 → v7
- Bump `actions/setup-node` from v6 → v7
- Refresh SHA pins for `dtolnay/rust-toolchain@stable`, `Swatinem/rust-cache@v2.9.1`, and `taiki-e/install-action` v2.83.2
- Updated workflow: `ci.yml`

## Test plan
- [x] Confirm CI (Node + Rust) passes on this PR
- [x] Verify rust-toolchain, rust-cache, and install-action still resolve correctly