### PR TITLE
fix(ci): pass toolchain input for SHA-pinned rust-toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,10 @@ jobs:
           pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Rust (wasm32)
-        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # stable
         with:
+          # Required when the action is SHA-pinned (ref name is not "stable").
+          toolchain: stable
           targets: wasm32-unknown-unknown
 
       - name: Rust dependency cache
@@ -71,8 +73,10 @@ jobs:
           pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Rust (llvm-cov + wasm32 for build:wasm)
-        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # stable
         with:
+          # Required when the action is SHA-pinned (ref name is not "stable").
+          toolchain: stable
           components: llvm-tools-preview
           targets: wasm32-unknown-unknown
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
     timeout-minutes: 35
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f # v7.0.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@363be39a57dfa5801e05c6e0c549d622a376cf15 # v7.0.0
         with:
           node-version-file: .nvmrc
           package-manager-cache: false
@@ -31,17 +31,17 @@ jobs:
           pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Rust (wasm32)
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88
         with:
           targets: wasm32-unknown-unknown
 
       - name: Rust dependency cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        uses: Swatinem/rust-cache@7e35be21c2b94d972b1143087fabc27d7dc881ef
         with:
           workspaces: tamil-seiyul-alagi
 
       - name: wasm-pack
-        uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # latest
+        uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 # v2.83.2
         with:
           tool: wasm-pack@0.13.1
 
@@ -56,10 +56,10 @@ jobs:
     timeout-minutes: 40
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f # v7.0.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@363be39a57dfa5801e05c6e0c549d622a376cf15 # v7.0.0
         with:
           node-version-file: .nvmrc
           package-manager-cache: false
@@ -71,23 +71,23 @@ jobs:
           pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Rust (llvm-cov + wasm32 for build:wasm)
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88
         with:
           components: llvm-tools-preview
           targets: wasm32-unknown-unknown
 
       - name: Rust dependency cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        uses: Swatinem/rust-cache@7e35be21c2b94d972b1143087fabc27d7dc881ef
         with:
           workspaces: tamil-seiyul-alagi
 
       - name: wasm-pack
-        uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # latest
+        uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 # v2.83.2
         with:
           tool: wasm-pack@0.13.1
 
       - name: cargo-llvm-cov
-        uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # latest
+        uses: taiki-e/install-action@43aecc8d72668fbcfe75c31400bc4f890f1c5853 # v2.83.2
         with:
           tool: cargo-llvm-cov
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Fixes the CI break from SHA-pinning `dtolnay/rust-toolchain` (same change as #80)
- When the action is pinned to a commit SHA, it can no longer infer the channel from `@stable`, so `toolchain: stable` is now required
- Adds that input on both the `build` and `crap_analysis` jobs

## Context
PR #80 pinned `dtolnay/rust-toolchain@stable` to commit `fa04a145…`. CI failed immediately with:

```
'toolchain' is a required input
```

This PR includes #80’s action pin updates plus the missing `toolchain: stable` input.

## Test plan
- [ ] Confirm `build` and `crap_analysis` get past the Rust toolchain step
- [ ] Confirm full CI gate still passes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc52f92c-6a5f-4dd0-9090-565b30973516"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc52f92c-6a5f-4dd0-9090-565b30973516"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

